### PR TITLE
Adding terraform and terragrunt in the git ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,10 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# Terragrunt and Terraform
+.terragrunt*
+.terraform.lock.hcl
+
 # pytype static type analyzer
 .pytype/
 

--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,25 @@ dmypy.json
 # Terragrunt and Terraform
 .terragrunt*
 .terraform.lock.hcl
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfstate.lock.info
+
+# Ignored Terraform files
+*gitignore*.tf
+
+# Backup files
+*.bak
+
+# Ignore Mac .DS_Store files
+.DS_Store
+
+# Ignore local stack data file
+.devcontainer/data
+
+# Ignored vscode files
+.vscode/
 
 # pytype static type analyzer
 .pytype/
@@ -154,4 +173,3 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-


### PR DESCRIPTION
# Summary | Résumé

Added terragrunt and terraform lock and cache files to be ignored by github. 