### PR TITLE
fix: throw exceptions instead of returning JSON

### DIFF
--- a/api/routers/shortener.py
+++ b/api/routers/shortener.py
@@ -53,7 +53,7 @@ def create_shortened_url(
 			}
 	except Exception as err:
 		data = {
-			"error": f"Error in processing shortened url {err}"
+			"error": f"Error in processing shortened url: {err}"
 			}
 	if len(accept.split(",")) > 1:
 		return templates.TemplateResponse("index.html", context={"request":request, "data":data})

--- a/api/utils/helpers.py
+++ b/api/utils/helpers.py
@@ -24,22 +24,19 @@ def generate_short_url(original_url: str, timestamp: float):
 
 # Function to return the shortened url
 def return_short_url(original_url, db_session):
+	timestamp = datetime.now().replace(tzinfo=timezone.utc).timestamp()
 	try:
-		timestamp = datetime.now().replace(tzinfo=timezone.utc).timestamp()
-		try:
-			resp = advocate.get(original_url)
-		except advocate.UnacceptableAddressException:
-			return {"error": "That URL points to a forbidden resource"}
-		except requests.RequestException:
-			return {"error": "Failed to connect to the specified URL"}
-		short_url = generate_short_url(original_url, timestamp)
-		short_url_obj = ShortUrls(
-			original_url=original_url, short_url=short_url)
-		db_session.add(short_url_obj)
-		db_session.commit()
-		return short_url
-	except Exception as err:
-		return {"error": f"error in processing shortened url"}
+		resp = advocate.get(original_url)
+	except advocate.UnacceptableAddressException:
+		raise Exception("That URL points to a forbidden resource")
+	except requests.RequestException:
+		raise Exception("Failed to connect to the specified URL")
+	short_url = generate_short_url(original_url, timestamp)
+	short_url_obj = ShortUrls(
+		original_url=original_url, short_url=short_url)
+	db_session.add(short_url_obj)
+	db_session.commit()
+	return short_url
 
 
 def is_domain_allowed(original_url, db_session):


### PR DESCRIPTION
# Summary | Résumé

The `return_short_url` function was returning a JSON object, instead of raising an exception.

# Test instructions | Instructions pour tester la modification

Add a URL to the `allowed_domains` that is not functional or does not exist. Try and shorten that URL. You should see the displayed error: "Failed to connect to the specified URL".