### PR TITLE
feat: add Terraform to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,6 +30,14 @@
 		"ms-python.vscode-pylance"
 	],
 
+	"features": {
+		"terraform": {
+			"version": "1.3.7",
+			"tflint": "latest",
+			"terragrunt": "0.40.2"
+		}
+	},	
+
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// This can be used to network with other containers or the host.
 	// "forwardPorts": [5000, 5432],


### PR DESCRIPTION
# Summary
Add Terraform and Terragrunt to the devcontainer
using the `terraform` feature.