### PR TITLE
feat: Rename route to v1

### DIFF
--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -50,3 +50,4 @@ jobs:
           AWS_ACCESS_KEY_ID: "AWS_ACCESS_KEY_ID"
           AWS_SECRET_ACCESS_KEY: "AWS_SECRET_ACCESS_KEY"
           AWS_REGION: "ca-central-1"
+          DYNAMODB_HOST: "http://localhost:9000"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To use the API, you can use [httpie](https://httpie.io/), [postman](https://www.
 Execute a POST request with 
 
 ```
-http://localhost:8000/shorten 
+http://localhost:8000/v1 
 ```
 In the body pass the following:
 ```{
@@ -62,14 +62,14 @@ In the body pass the following:
 
 #### curl
 ```
-curl -X POST -d '{"original_url": "https://google.com"}' -H "Content-Type: application/json" http://localhost:8000/shorten
+curl -X POST -d '{"original_url": "https://google.com"}' -H "Content-Type: application/json" http://localhost:8000/v1
 
 {"status":"OK","short_url":"xM_ElQWt"}
 ```
 
 #### httpie
 ```
-http POST localhost:8000/shorten original_url=http://www.google.com
+http POST localhost:8000/v1 original_url=http://www.google.com
 
 HTTP/1.1 200 OK
 content-length: 38

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -3,7 +3,6 @@ testpaths = tests
 asyncio_mode = auto
 env =  
     ALLOWED_DOMAINS=canada.ca,gc.ca
-    DYNAMODB_HOST=http://localhost:9000
     TABLE_NAME=url_shortener_test
     TEST=True
     FORMS_URL=http://forms_url

--- a/api/routers/shortener.py
+++ b/api/routers/shortener.py
@@ -35,7 +35,7 @@ def create_shortened_url(
     )
 
 
-@router.post("/shorten", status_code=status.HTTP_201_CREATED)
+@router.post("/v1", status_code=status.HTTP_201_CREATED)
 def create_shortened_url_api(
     original_url: HttpUrl = Body(..., embed=True),
 ):

--- a/api/tests/routers/test_shortener.py
+++ b/api/tests/routers/test_shortener.py
@@ -17,18 +17,18 @@ def test_POST_homepage_returns_200(client):
 
 
 def test_creating_a_valid_shortlink(client):
-    response = client.post("/shorten", json={"original_url": "https://www.canada.ca"})
+    response = client.post("/v1", json={"original_url": "https://www.canada.ca"})
     assert response.status_code == status.HTTP_201_CREATED
     assert response.json()["status"] == "OK"
 
 
 def test_creating_a_blocked_shortlink(client):
-    response = client.post("/shorten", json={"original_url": "https://www.example.ca"})
+    response = client.post("/v1", json={"original_url": "https://www.example.ca"})
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
 def test_known_shorturl_redirects_to_original_url(client):
-    response = client.post("/shorten", json={"original_url": "https://www.canada.ca"})
+    response = client.post("/v1", json={"original_url": "https://www.canada.ca"})
     shorturl = response.json()["short_url"].split("/")[-1]
 
     # See https://github.com/tiangolo/fastapi/issues/790

--- a/api/utils/helpers.py
+++ b/api/utils/helpers.py
@@ -117,6 +117,7 @@ def validate_and_shorten_url(original_url):
                 }
 
             shortener_domain = os.getenv("SHORTENER_DOMAIN") or ""
+            log.info(f"Shortened URL: {short_url} from {original_url}")
             data = {
                 "short_url": f"{shortener_domain}{short_url}",
                 "original_url": original_url,


### PR DESCRIPTION
Closes #83. This PR renames the `shorten` route to `v1`. We decided not to overload the `POST /` route with JSON and Form Data because of future UI considerations. Renaming it to `v1` allows for future versions of APIs to be implemented.