### PR TITLE
Feat/redirect page

### DIFF
--- a/api/static/css/styles.css
+++ b/api/static/css/styles.css
@@ -1,4 +1,5 @@
 @charset "UTF-8";
+
 * {
   box-sizing: border-box;
 }
@@ -31,6 +32,7 @@ ul {
 }
 
 @media screen and (min-width: 21em) {
+
   p,
   .multiple-choice__item p,
   ol,
@@ -45,6 +47,7 @@ ul {
 }
 
 @media screen and (min-width: 35.5em) {
+
   ol,
   ul {
     padding-left: 40px;
@@ -88,7 +91,7 @@ main {
   padding-bottom: 60px;
 }
 
-main > div {
+main>div {
   margin-bottom: 30px;
 }
 
@@ -157,18 +160,22 @@ footer .canada-wordmark {
     justify-content: space-between;
     align-items: center;
   }
+
   footer .page--container .footer-links {
     flex: 2;
   }
+
   footer .page--container .footer-links ul {
     margin-bottom: -5px;
   }
+
   footer .page--container .canada-wordmark {
     flex: 1;
     text-align: right;
     margin-bottom: 0;
     max-height: 100%;
   }
+
   footer .page--container .canada-wordmark img {
     height: 40px;
     margin-bottom: 10px;
@@ -208,6 +215,7 @@ header .fip-container li button {
 }
 
 @media screen and (min-width: 35.5em) {
+
   header .fip-container li a,
   header .fip-container li button {
     margin: 0;
@@ -284,4 +292,8 @@ nav ul li a {
 
 .nav--main.anonymous {
   border-bottom: 3px solid #26374a;
+}
+
+.redirect_link {
+  text-decoration: underline;
 }

--- a/api/templates/404.html
+++ b/api/templates/404.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% set active_page = "redirect" %}
+
+{% block title %}URL Shortener {% endblock %}
+
+{% block page_content %}
+<h1>404 Not found / 404 Non trouvé</h1>
+The requested link could not be found.
+<br />
+<br />
+Le lien demandé n'a pas pu être trouvé.
+{% endblock %}

--- a/api/templates/404.html
+++ b/api/templates/404.html
@@ -5,8 +5,6 @@
 
 {% block page_content %}
 <h1>404 Not found / 404 Non trouvé</h1>
-The requested link could not be found.
-<br />
-<br />
-Le lien demandé n'a pas pu être trouvé.
+<p>The requested link could not be found.</p>
+<p>Le lien demandé n'a pas pu être trouvé.</p>
 {% endblock %}

--- a/api/templates/redirect.html
+++ b/api/templates/redirect.html
@@ -5,23 +5,14 @@
 
 {% block page_content %}
 <h1>Redirect Notice / Avis de redirection</h1>
-The previous page is sending you to / La page précédente vous envoie à :
-<br />
-<br />
-<a class="redirect_link" href="{{ data.url }}">{{ data.url }}</a>
-<br />
-<br />
-If you want to continue, please click the link above.
-<br />
-<br />
-Si vous voulez continuer, cliquez sur le lien ci-dessus.
-<br />
-<br />
-If you do not want to visit that page, you can <a class="redirect_link" href="#" onclick="history.back()">return to the
-    previous page</a>.
-<br />
-<br />
-Si vous ne voulez pas visiter cette page, vous pouvez <a class="redirect_link" href="#"
-    onclick="history.back()">retourner à la page
-    précédente</a>.
+<p>The previous page is sending you to / La page précédente vous envoie à:</p>
+<p><a class="redirect_link" href="{{ data.url }}">{{ data.url }}</a></p>
+<p>If you want to continue, please click the link above.</p>
+<p>Si vous voulez continuer, cliquez sur le lien ci-dessus.</p>
+<p>If you do not want to visit that page, you can <a class="redirect_link" href="#" onclick="history.back()">return to
+        the
+        previous page</a>.</p>
+<p>Si vous ne voulez pas visiter cette page, vous pouvez <a class="redirect_link" href="#"
+        onclick="history.back()">retourner à la page
+        précédente</a>.</p>
 {% endblock %}

--- a/api/templates/redirect.html
+++ b/api/templates/redirect.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% set active_page = "redirect" %}
+
+{% block title %}URL Shortener {% endblock %}
+
+{% block page_content %}
+<h1>Redirect Notice / Avis de redirection</h1>
+The previous page is sending you to / La page précédente vous envoie à :
+<br />
+<br />
+<a class="redirect_link" href="{{ data.url }}">{{ data.url }}</a>
+<br />
+<br />
+If you want to continue, please click the link above.
+<br />
+<br />
+Si vous voulez continuer, cliquez sur le lien ci-dessus.
+<br />
+<br />
+If you do not want to visit that page, you can <a class="redirect_link" href="#" onclick="history.back()">return to the
+    previous page</a>.
+<br />
+<br />
+Si vous ne voulez pas visiter cette page, vous pouvez <a class="redirect_link" href="#"
+    onclick="history.back()">retourner à la page
+    précédente</a>.
+{% endblock %}

--- a/api/tests/routers/test_shortener.py
+++ b/api/tests/routers/test_shortener.py
@@ -27,6 +27,14 @@ def test_creating_a_blocked_shortlink(client):
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
+def test_creating_a_blocked_shortlink_with_ending_match(client):
+    response = client.post("/v1", json={"original_url": "https://www.examplegc.ca"})
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    response = client.post("/v1", json={"original_url": "https://www.examplecanada.ca"})
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
 def test_known_shorturl_displays_original_url(client):
     response = client.post(
         "/v1",

--- a/api/tests/routers/test_shortener.py
+++ b/api/tests/routers/test_shortener.py
@@ -27,12 +27,15 @@ def test_creating_a_blocked_shortlink(client):
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_known_shorturl_redirects_to_original_url(client):
-    response = client.post("/v1", json={"original_url": "https://www.canada.ca"})
+def test_known_shorturl_displays_original_url(client):
+    response = client.post(
+        "/v1",
+        json={
+            "original_url": "https://www.canada.ca/en/services/jobs/opportunities.html"
+        },
+    )
     shorturl = response.json()["short_url"].split("/")[-1]
 
-    # See https://github.com/tiangolo/fastapi/issues/790
-    # For discussion of the allow_redirect = False
-    response = client.get(f"/{shorturl}", allow_redirects=False)
-    assert response.headers["location"] == "https://www.canada.ca"
-    assert response.status_code == status.HTTP_302_FOUND
+    response = client.get(f"/{shorturl}")
+    assert "https://www.canada.ca/en/services/jobs/opportunities.html" in response.text
+    assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
This PR adds a redirect page proof of concept and also a custom 404 page. I thought it might be nice to be able to demo this aspect of the app earlier just to provide additional assurances that people will not be redirected to malicious domains automatically. Even if somebody finds an open redirect on a canada.ca domain, hopefully this could make it more obvious. We would also need to do additional work around language and content.

Redirect

![Screenshot 2023-02-10 at 12 40 39 PM](https://user-images.githubusercontent.com/867334/218160084-2262916c-f62a-4119-bacc-6eb052db01ed.png)

Custom 404

![Screenshot 2023-02-10 at 12 40 58 PM](https://user-images.githubusercontent.com/867334/218160148-92f1518a-7694-42f2-823a-58a4f65f4a56.png)

