### PR TITLE
Fixing up referencing env variable within environment variable block

### DIFF
--- a/.github/workflows/build_and_push_staging.yml
+++ b/.github/workflows/build_and_push_staging.yml
@@ -8,7 +8,7 @@ on:
 env:
   GITHUB_SHA: ${{ github.sha }}
   AWS_ACCOUNT_STAGING: 843973686572
-  REGISTRY: ${{env.AWS_ACCOUNT_STAGING}}.dkr.ecr.ca-central-1.amazonaws.com/url-shortener/api
+  REGISTRY: 843973686572.dkr.ecr.ca-central-1.amazonaws.com/url-shortener/api
   AWS_REGION: ca-central-1
 
 permissions:


### PR DESCRIPTION
# Summary | Résumé
So you were totally right - you can't use environment variables within the environment variables block. This PR fixes this. 