### PR TITLE
Fixing a bug in the ECR registry name

### DIFF
--- a/.github/workflows/build_and_push_staging.yml
+++ b/.github/workflows/build_and_push_staging.yml
@@ -8,7 +8,7 @@ on:
 env:
   GITHUB_SHA: ${{ github.sha }}
   AWS_ACCOUNT_STAGING: 843973686572
-  REGISTRY: 843973686572.dkr.ecr.ca-central-1.amazonaws.com/url-shortener/api
+  REGISTRY: 843973686572.dkr.ecr.ca-central-1.amazonaws.com/url-shortener
   AWS_REGION: ca-central-1
 
 permissions:


### PR DESCRIPTION
# Summary | Résumé

Correcting the name of the URL shortener ECR registry since it was previously incorrect and the action was failing. 