### PR TITLE
Added the forwarded values for the cloudfront distribution

### DIFF
--- a/terragrunt/aws/cloudfront/cloudfront.tf
+++ b/terragrunt/aws/cloudfront/cloudfront.tf
@@ -28,7 +28,15 @@ resource "aws_cloudfront_distribution" "url_shortener_api" {
     default_ttl = 86400    # 24 hours
     max_ttl     = 31536000 # 365 days
     compress    = true
+
+    forwarded_values {
+      query_string = true
+      headers      = ["Authorization"]
+      cookies {
+        forward = "none"
+      }
   }
+}
 
   # Prevent caching of healthcheck calls
   ordered_cache_behavior {

--- a/terragrunt/aws/cloudfront/cloudfront.tf
+++ b/terragrunt/aws/cloudfront/cloudfront.tf
@@ -35,8 +35,8 @@ resource "aws_cloudfront_distribution" "url_shortener_api" {
       cookies {
         forward = "none"
       }
+    }
   }
-}
 
   # Prevent caching of healthcheck calls
   ordered_cache_behavior {


### PR DESCRIPTION
# Summary | Résumé

I had previously omitted the required values for the cloudfront distribution and terraform apply was failing even though terraform plan was fine. 