### PR TITLE
Removing the domain variable and adding the shortener domain env variable needed by the lambda function

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -15,8 +15,8 @@ module "url_shortener_lambda" {
   }
 
   environment_variables = {
-    DOMAIN                    = var.domain
     API_AUTH_TOKEN_SECRET_ARN = aws_ssm_parameter.api_auth_token.arn
+    SHORTENER_DOMAIN          = "https://${var.domain}/"
   }
 
   policies = [


### PR DESCRIPTION
# Summary | Résumé

The lambda function does not need the DOMAIN environment variable but instead the SHORTENER_DOMAIN environment variable. 