### PR TITLE
Fix/add additional regex char to WAF rule

### DIFF
--- a/terragrunt/aws/cloudfront/waf.tf
+++ b/terragrunt/aws/cloudfront/waf.tf
@@ -245,7 +245,7 @@ resource "aws_wafv2_regex_pattern_set" "valid_uri_paths" {
 
   # allow base64 and get short url
   regular_expression {
-    regex_string = "^/[0-9A-Za-z+_/=-]{8}$"
+    regex_string = "^/[0-9A-Za-z-+_/=]{8}$"
   }
 
   # allow homepage 

--- a/terragrunt/aws/cloudfront/waf.tf
+++ b/terragrunt/aws/cloudfront/waf.tf
@@ -245,7 +245,7 @@ resource "aws_wafv2_regex_pattern_set" "valid_uri_paths" {
 
   # allow base64 and get short url
   regular_expression {
-    regex_string = "^/[0-9A-Za-z+_/=]{8}$"
+    regex_string = "^/[0-9A-Za-z+_/=-]{8}$"
   }
 
   # allow homepage 


### PR DESCRIPTION
# Summary | Résumé

Add - to the regex character set so that WAF does not block any shortened string containing it. Closes #133 