### PR TITLE
fix: moved ALLOWED_DOMAINS from ssm to lambda env

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -17,6 +17,7 @@ module "url_shortener_lambda" {
   environment_variables = {
     API_AUTH_TOKEN_SECRET_ARN = aws_ssm_parameter.api_auth_token.arn
     SHORTENER_DOMAIN          = "https://${var.domain}/"
+    ALLOWED_DOMAINS           = "canada.ca,gc.ca"
   }
 
   policies = [

--- a/terragrunt/aws/api/ssm.tf
+++ b/terragrunt/aws/api/ssm.tf
@@ -1,7 +1,7 @@
 resource "aws_ssm_parameter" "api_auth_token" {
   name  = "api_auth_token"
   type  = "SecureString"
-  value = "API_AUTH_TOKEN=${var.api_auth_token}\nALLOWED_DOMAINS=canada.ca, gc.ca"
+  value = "API_AUTH_TOKEN=${var.api_auth_token}"
 
   tags = {
     CostCentre = var.billing_code


### PR DESCRIPTION
Closes https://github.com/cds-snc/url-shortener/issues/143.

This PR moves ALLOWED_DOMAINS from aws_ssm_parameter resource to lambda environment variables.