### PR TITLE
DynamoDB TTL integration (2 years)

### DIFF
--- a/api/models/ShortUrls.py
+++ b/api/models/ShortUrls.py
@@ -21,7 +21,6 @@ def create_short_url(original_url, short_url):
     the shortened URL is returned.
     Otherwise, this is a collision and a ValueError exception is raised.
     The caller should try again with a new short_url.
-    
     parameter original_url: the url that the user passes to the api
     parameter short_url: short url mapped to the original url
 
@@ -32,16 +31,16 @@ def create_short_url(original_url, short_url):
     expiry_date = int(time.mktime(two_years_time.timetuple()))
     try:
         response = client.put_item(
-          TableName=table,
-          Item={
-            "short_url": {"S": short_url},
-            "original_url": {"S": original_url},
-            "click_count": {"N": "0"},
-            "active": {"BOOL": True},
-            "created": {"S": str(datetime.datetime.utcnow())},
-            "ttl": {"N": str(expiry_date)},
-          },
-          ConditionExpression="attribute_not_exists(short_url)",
+            TableName=table,
+            Item={
+                "short_url": {"S": short_url},
+                "original_url": {"S": original_url},
+                "click_count": {"N": "0"},
+                "active": {"BOOL": True},
+                "created": {"S": str(datetime.datetime.utcnow())},
+                "ttl": {"N": str(expiry_date)},
+            },
+            ConditionExpression="attribute_not_exists(short_url)",
         )
         if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
             raise RuntimeError(response)

--- a/api/models/ShortUrls.py
+++ b/api/models/ShortUrls.py
@@ -1,5 +1,6 @@
 import boto3
 import datetime
+import time
 import os
 
 client = boto3.client(
@@ -12,6 +13,9 @@ table = os.environ.get("TABLE_NAME", "url_shortener")
 
 
 def create_short_url(original_url, short_url):
+    # Expire an url after 2 years in epoch time
+    two_years_time = datetime.datetime.today() + datetime.timedelta(days=(365 * 2))
+    expiry_date = int(time.mktime(two_years_time.timetuple()))
     response = client.put_item(
         TableName=table,
         Item={
@@ -20,6 +24,7 @@ def create_short_url(original_url, short_url):
             "click_count": {"N": "0"},
             "active": {"BOOL": True},
             "created": {"S": str(datetime.datetime.utcnow())},
+            "ttl": {"N": str(expiry_date)},
         },
     )
 
@@ -30,12 +35,25 @@ def create_short_url(original_url, short_url):
 
 
 def get_short_url(short_url):
-    response = client.get_item(
+    # AWS does not delete expired items immediately (typically deletes within 48 hours) so we still need to sure we don't return any expired urls
+    epochTimeNow = int(time.time())
+    response = client.query(
         TableName=table,
-        Key={"short_url": {"S": short_url}},
-        ProjectionExpression="short_url, original_url, click_count, active, created",
+        KeyConditionExpression="#short_url = :short_url",
+        FilterExpression="#t > :ttl",
+        ExpressionAttributeNames={"#t": "ttl", "#short_url": "short_url"},
+        ExpressionAttributeValues={
+            ":ttl": {
+                "N": str(epochTimeNow),
+            },
+            ":short_url": {"S": short_url},
+        },
     )
-    if response["ResponseMetadata"]["HTTPStatusCode"] == 200 and "Item" in response:
-        return response["Item"]
+    if (
+        response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        and "Items" in response
+        and len(response["Items"]) > 0
+    ):
+        return response["Items"][0]
     else:
         return None

--- a/api/tests/models/test_ShortUrls.py
+++ b/api/tests/models/test_ShortUrls.py
@@ -2,7 +2,6 @@ import unittest
 from models import ShortUrls
 import time
 import datetime
-from unittest.mock import patch
 
 
 class TestCreateShortUrl(unittest.TestCase):
@@ -14,12 +13,6 @@ class TestCreateShortUrl(unittest.TestCase):
         url_a = ShortUrls.create_short_url("https://www.canada.ca", "test1234")
         url_b = ShortUrls.create_short_url("https://www.canada.ca", "test1234")
         assert url_a == url_b
-
-    @patch("models.ShortUrls.client.put_item")
-    def test_create_short_url_with_existing_url(self, mock_put_item):
-        mock_put_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 400}}
-        short_url = ShortUrls.create_short_url("https://www.canada.ca", "test")
-        assert short_url is None
 
     def test_get_short_url(self):
         ShortUrls.create_short_url("https://www.canada.ca", "test")

--- a/api/tests/models/test_ShortUrls.py
+++ b/api/tests/models/test_ShortUrls.py
@@ -16,22 +16,22 @@ class TestCreateShortUrl(unittest.TestCase):
         assert url_a == url_b
 
     @patch("models.ShortUrls.client.put_item")
-    def test_create_short_url_with_existing_url(mock_put_item):
+    def test_create_short_url_with_existing_url(self, mock_put_item):
         mock_put_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 400}}
         short_url = ShortUrls.create_short_url("https://www.canada.ca", "test")
         assert short_url is None
 
-    def test_get_short_url():
+    def test_get_short_url(self):
         ShortUrls.create_short_url("https://www.canada.ca", "test")
         short_url = ShortUrls.get_short_url("test")
         assert short_url["original_url"]["S"] == "https://www.canada.ca"
 
-    def test_ttl_is_valid():
+    def test_ttl_is_valid(self):
         short_url = ShortUrls.get_short_url("test")
         epoch_time_now = int(time.time())
         assert int(short_url["ttl"]["N"]) > epoch_time_now
 
-    def test_ttl_is_invalid():
+    def test_ttl_is_invalid(self):
         future_epoch_time = int(
             time.mktime(
                 (

--- a/api/tests/models/test_ShortUrls.py
+++ b/api/tests/models/test_ShortUrls.py
@@ -15,29 +15,21 @@ class TestCreateShortUrl(unittest.TestCase):
         url_b = ShortUrls.create_short_url("https://www.canada.ca", "test1234")
         assert url_a == url_b
 
-    def test_get_short_url(self):
-        ShortUrls.create_short_url("https://www.canada.ca", "test1234")
-        short_url = ShortUrls.get_short_url("test1234")
-        assert short_url["original_url"]["S"] == "https://www.canada.ca"
-
     @patch("models.ShortUrls.client.put_item")
     def test_create_short_url_with_existing_url(mock_put_item):
         mock_put_item.return_value = {"ResponseMetadata": {"HTTPStatusCode": 400}}
         short_url = ShortUrls.create_short_url("https://www.canada.ca", "test")
         assert short_url is None
 
-
     def test_get_short_url():
         ShortUrls.create_short_url("https://www.canada.ca", "test")
         short_url = ShortUrls.get_short_url("test")
         assert short_url["original_url"]["S"] == "https://www.canada.ca"
 
-
-   def test_ttl_is_valid():
+    def test_ttl_is_valid():
         short_url = ShortUrls.get_short_url("test")
         epoch_time_now = int(time.time())
         assert int(short_url["ttl"]["N"]) > epoch_time_now
-
 
     def test_ttl_is_invalid():
         future_epoch_time = int(
@@ -47,7 +39,7 @@ class TestCreateShortUrl(unittest.TestCase):
         )
         short_url = ShortUrls.get_short_url("test")
         assert short_url["ttl"]["N"] < str(future_epoch_time)
-    
+
     def test_create_short_url_with_different_url_but_same_hash__raises_value_error_for_collision(
         self,
     ):

--- a/api/tests/models/test_ShortUrls.py
+++ b/api/tests/models/test_ShortUrls.py
@@ -1,5 +1,6 @@
 from models import ShortUrls
-
+import time
+import datetime
 from unittest.mock import patch
 
 
@@ -19,3 +20,19 @@ def test_get_short_url():
     ShortUrls.create_short_url("https://www.canada.ca", "test")
     short_url = ShortUrls.get_short_url("test")
     assert short_url["original_url"]["S"] == "https://www.canada.ca"
+
+
+def test_ttl_is_valid():
+    short_url = ShortUrls.get_short_url("test")
+    epoch_time_now = int(time.time())
+    assert int(short_url["ttl"]["N"]) > epoch_time_now
+
+
+def test_ttl_is_invalid():
+    future_epoch_time = int(
+        time.mktime(
+            (datetime.datetime.today() + datetime.timedelta(days=(365 * 5))).timetuple()
+        )
+    )
+    short_url = ShortUrls.get_short_url("test")
+    assert short_url["ttl"]["N"] < str(future_epoch_time)

--- a/api/tests/models/test_ShortUrls.py
+++ b/api/tests/models/test_ShortUrls.py
@@ -34,7 +34,9 @@ class TestCreateShortUrl(unittest.TestCase):
     def test_ttl_is_invalid():
         future_epoch_time = int(
             time.mktime(
-                (datetime.datetime.today() + datetime.timedelta(days=(365 * 5))).timetuple()
+                (
+                    datetime.datetime.today() + datetime.timedelta(days=(365 * 5))
+                ).timetuple()
             )
         )
         short_url = ShortUrls.get_short_url("test")

--- a/api/tests/utils/test_helpers.py
+++ b/api/tests/utils/test_helpers.py
@@ -238,7 +238,7 @@ def test_resolve_short_url_returns_original_url_with_valid_ttl(mock_short_urls_m
 
 
 @patch("utils.helpers.ShortUrls")
-def test_resolve_short_url_does_not_return_original_url_invalid_ttl(
+def test_resolve_short_url_does_not_return_original_url_expired_ttl(
     mock_short_urls_model,
 ):
     mock_short_urls_model.create_short_url = MagicMock(

--- a/api/tests/utils/test_helpers.py
+++ b/api/tests/utils/test_helpers.py
@@ -2,6 +2,9 @@ from utils import helpers
 
 from unittest.mock import MagicMock, patch
 
+import datetime
+import time
+
 import advocate
 import requests
 import os
@@ -211,3 +214,41 @@ def test_validate_and_shorten_url_returns_success_with_domain():
         "short_url": "https://foo.bar/XjbS35ah",
         "status": "OK",
     }
+
+
+@patch("utils.helpers.ShortUrls")
+def test_resolve_short_url_returns_original_url_with_valid_ttl(mock_short_urls_model):
+    # get epoch time for 2 years in the future
+    future_epoch_time = int(
+        time.mktime(
+            (datetime.datetime.today() + datetime.timedelta(days=(365 * 2))).timetuple()
+        )
+    )
+    mock_short_urls_model.create_short_url = MagicMock(
+        ttl=str(future_epoch_time),
+        original_url="https://foo_bar.com",
+        short_url="foo_bar",
+        click_count=0,
+        active=True,
+        created="2023-03-14 20:58:47.603829",
+    )
+    mock_short_urls_model.get_short_url.return_value = "https://foo_bar.com"
+    result = helpers.resolve_short_url("foo_bar")
+    assert result == "https://foo_bar.com"
+
+
+@patch("utils.helpers.ShortUrls")
+def test_resolve_short_url_does_not_return_original_url_invalid_ttl(
+    mock_short_urls_model,
+):
+    mock_short_urls_model.create_short_url = MagicMock(
+        ttl="100",
+        original_url="https://foo_bar.com",
+        short_url="foo_bar",
+        click_count=0,
+        active=True,
+        created="2023-03-14 20:58:47.603829",
+    )
+    mock_short_urls_model.get_short_url.return_value = None
+    result = helpers.resolve_short_url("foo_bar")
+    assert result is False

--- a/terragrunt/aws/dynamodb/url_shortener_table.tf
+++ b/terragrunt/aws/dynamodb/url_shortener_table.tf
@@ -17,6 +17,11 @@ resource "aws_dynamodb_table" "url_shortener" {
     enabled = true
   }
 
+  ttl {
+    attribute_name = "TimeToExist"
+    enabled        = false
+  }
+
   tags = {
     CostCentre = var.billing_code
     Terraform  = true

--- a/terragrunt/aws/dynamodb/url_shortener_table.tf
+++ b/terragrunt/aws/dynamodb/url_shortener_table.tf
@@ -18,7 +18,7 @@ resource "aws_dynamodb_table" "url_shortener" {
   }
 
   ttl {
-    attribute_name = "TimeToExist"
+    attribute_name = "ttl"
     enabled        = false
   }
 


### PR DESCRIPTION
# Summary | Résumé

Enabled TTL on the DynamoDB database to automatically delete and expire entries after 2 years. Closes #97 

Changes made:

- Terraform DynamoDB change to enable the TTL functionality
- Changed the create_short_url function to set the TTL for each entry to be epoch time of 2 years in the future
- Changed the get_short_url function to retrieve only entries that have a valid TTL. Since AWS does not automatically delete expired entries and it takes up to 48 hours for this change to be made, this was needed
- Wrote unit tests to test the above. 
