### PR TITLE
Modifying WAF regex rules to allow [0-9A-Za-z] character set

### DIFF
--- a/terragrunt/aws/cloudfront/waf.tf
+++ b/terragrunt/aws/cloudfront/waf.tf
@@ -245,7 +245,7 @@ resource "aws_wafv2_regex_pattern_set" "valid_uri_paths" {
 
   # allow base64 and get short url
   regular_expression {
-    regex_string = "^/[0-9A-Za-z-+_/=]{8}$"
+    regex_string = "^/[0-9A-Za-z]{8}$"
   }
 
   # allow homepage 


### PR DESCRIPTION
# Summary | Résumé
 
Due to the [deterministic hashing change](https://github.com/cds-snc/url-shortener/pull/153), the character set for shortened url has changed to only [0-9A-Za-z]. I am modifying the Waf regex rules to allow only those character sets. 