### PR TITLE
Added IAM permission to read hashing_peppers from parameter store

### DIFF
--- a/terragrunt/aws/api/iam.tf
+++ b/terragrunt/aws/api/iam.tf
@@ -22,7 +22,8 @@ data "aws_iam_policy_document" "api_policies" {
       "ssm:GetParameters",
     ]
     resources = [
-      aws_ssm_parameter.api_auth_token.arn
+      aws_ssm_parameter.api_auth_token.arn,
+      aws_ssm_parameter.hashing_peppers.arn
     ]
   }
 }


### PR DESCRIPTION
This closes https://github.com/cds-snc/url-shortener/issues/172

Root cause: The IAM permission to read hashing_peppers ssm resource is missing.

Added missing IAM permission.