### PR TITLE
Enabled WAF logging to cloudwatch logs log group

### DIFF
--- a/terragrunt/aws/cloudfront/waf.tf
+++ b/terragrunt/aws/cloudfront/waf.tf
@@ -263,3 +263,23 @@ resource "aws_wafv2_regex_pattern_set" "valid_uri_paths" {
     Terraform  = true
   }
 }
+
+resource "aws_cloudwatch_log_group" "wafv2-log-group" {
+  name              = "aws-waf-logs-url-shortener"
+  retention_in_days = 90
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "waf_logging_configuration" {
+  log_destination_configs = [aws_cloudwatch_log_group.wafv2-log-group.arn]
+  resource_arn            = aws_wafv2_web_acl.api_waf.arn
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}

--- a/terragrunt/aws/cloudfront/waf.tf
+++ b/terragrunt/aws/cloudfront/waf.tf
@@ -264,9 +264,23 @@ resource "aws_wafv2_regex_pattern_set" "valid_uri_paths" {
   }
 }
 
+resource "aws_kms_key" "wafv2-log-group-kms-key" {
+  description              = "WAF Cloudwatch logs KMS key"
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  is_enabled               = true
+  enable_key_rotation      = true
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
 resource "aws_cloudwatch_log_group" "wafv2-log-group" {
   name              = "aws-waf-logs-url-shortener"
   retention_in_days = 90
+  kms_key_id        = aws_kms_key.wafv2-log-group-kms-key.arn
 
   tags = {
     CostCentre = var.billing_code

--- a/terragrunt/aws/cloudfront/waf.tf
+++ b/terragrunt/aws/cloudfront/waf.tf
@@ -277,9 +277,4 @@ resource "aws_cloudwatch_log_group" "wafv2-log-group" {
 resource "aws_wafv2_web_acl_logging_configuration" "waf_logging_configuration" {
   log_destination_configs = [aws_cloudwatch_log_group.wafv2-log-group.arn]
   resource_arn            = aws_wafv2_web_acl.api_waf.arn
-
-  tags = {
-    CostCentre = var.billing_code
-    Terraform  = true
-  }
 }


### PR DESCRIPTION
This closes: https://github.com/cds-snc/url-shortener/issues/176

The [doc](https://registry.terraform.io/providers/hashicorp/aws/4.52.0/docs/resources/wafv2_web_acl_logging_configuration) mentioned firehose is required. But this may not be the case fore CloudWatch Logs log group.
