### PR TITLE
KMS key policy to allow Cloudwatch logs access

### DIFF
--- a/terragrunt/aws/cloudfront/iam.tf
+++ b/terragrunt/aws/cloudfront/iam.tf
@@ -4,7 +4,9 @@ data "aws_iam_policy_document" "cloudfront_policies" {
     effect = "Allow"
 
     principals {
-      identifiers = [ "logs.${var.region}.amazonaws.com" ]
+      identifiers = [
+        "logs.${var.region}.amazonaws.com",
+      ]
       type = "Service"
     }
 
@@ -13,11 +15,11 @@ data "aws_iam_policy_document" "cloudfront_policies" {
       "kms:Decrypt*",
       "kms:ReEncrypt*",
       "kms:GenerateDataKey*",
-      "kms:Describe*"
+      "kms:Describe*",
     ]
 
     resources = [
-      "arn:aws:kms:::key/*"
+      "arn:aws:kms:::key/*",
     ]
 
     condition {

--- a/terragrunt/aws/cloudfront/iam.tf
+++ b/terragrunt/aws/cloudfront/iam.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "cloudfront_policies" {
     ]
 
     resources = [
-      "*"
+      "arn:aws:kms:::key/*"
     ]
 
     condition {

--- a/terragrunt/aws/cloudfront/iam.tf
+++ b/terragrunt/aws/cloudfront/iam.tf
@@ -1,0 +1,31 @@
+data "aws_iam_policy_document" "cloudfront_policies" {
+  statement {
+    sid    = "AllowKMSAccessToCloudWatchLogs"
+    effect = "Allow"
+
+    principals {
+      identifiers = [ "logs.${var.region}.amazonaws.com" ]
+      type = "Service"
+    }
+
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+
+    resources = [
+      "*"
+    ]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "kms:EncryptionContext:aws:logs:arn"
+      values = [
+        "arn:aws:logs:${var.region}:${var.account_id}:log-group:aws-waf-logs-${var.product_name}/",
+      ]
+    }
+  }
+}

--- a/terragrunt/aws/cloudfront/waf.tf
+++ b/terragrunt/aws/cloudfront/waf.tf
@@ -270,7 +270,7 @@ resource "aws_kms_key" "wafv2-log-group-kms-key" {
   customer_master_key_spec = "SYMMETRIC_DEFAULT"
   is_enabled               = true
   enable_key_rotation      = true
-  policy                   = aws_iam_policy_document.cloudfront_policies.json
+  policy                   = data.aws_iam_policy_document.cloudfront_policies.json
 
   tags = {
     CostCentre = var.billing_code

--- a/terragrunt/aws/cloudfront/waf.tf
+++ b/terragrunt/aws/cloudfront/waf.tf
@@ -270,6 +270,7 @@ resource "aws_kms_key" "wafv2-log-group-kms-key" {
   customer_master_key_spec = "SYMMETRIC_DEFAULT"
   is_enabled               = true
   enable_key_rotation      = true
+  policy                   = aws_iam_policy_document.cloudfront_policies.json
 
   tags = {
     CostCentre = var.billing_code
@@ -278,7 +279,7 @@ resource "aws_kms_key" "wafv2-log-group-kms-key" {
 }
 
 resource "aws_cloudwatch_log_group" "wafv2-log-group" {
-  name              = "aws-waf-logs-url-shortener"
+  name              = "aws-waf-logs-${var.product_name}"
   retention_in_days = 90
   kms_key_id        = aws_kms_key.wafv2-log-group-kms-key.arn
 


### PR DESCRIPTION
This closes: https://github.com/cds-snc/url-shortener/issues/178

Added Key policy to KMS so that it can be accessed by Cloudwatch logs log group.