### PR TITLE
Fixed policy, suppress CKV_AWS_111

### DIFF
--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -8,6 +8,8 @@ skip-check:
   - CKV2_AWS_47 # Cloudfront: No Log4j dependency and false positive, AWSManagedRulesKnownBadInputsRuleSet is being applied
   - CKV_AWS_51  # ECR: `latest` tag is used for development 
   - CKV_AWS_86  # CloudFront: Access logging not required
+  - CKV_AWS_109 # KMS: `resources=["*"]` references the key the policy is attached to
+  - CKV_AWS_111 # MKS: `resources=["*"]` references the key the policy is attached to
   - CKV_AWS_119 # DynamoDB default service key encryption is acceptable
   - CKV_AWS_136 # ECR: Default encryption key is acceptable 
   - CKV_AWS_192 # CloudFront: False-positive, AWSManagedRulesKnownBadInputsRuleSet is being applied 

--- a/terragrunt/aws/cloudfront/iam.tf
+++ b/terragrunt/aws/cloudfront/iam.tf
@@ -1,6 +1,7 @@
 data "aws_iam_policy_document" "cloudfront_policies" {
 
   #checkov:skip=CKV_AWS_111: Resource must be "*"
+  #checkov:skip=CKV_AWS_109: Resource must be "*"
   # See: https://stackoverflow.com/questions/41991480/the-new-key-policy-will-not-allow-you-to-update-the-key-policy-in-the-future
   # Resource – (Required) In a key policy, you use "*" for the resource, which means "this CMK."
   # A key policy applies only to the CMK it is attached to.

--- a/terragrunt/aws/cloudfront/iam.tf
+++ b/terragrunt/aws/cloudfront/iam.tf
@@ -1,5 +1,9 @@
 data "aws_iam_policy_document" "cloudfront_policies" {
 
+  #checkov:skip=CKV_AWS_111: Resource must be "*"
+  # See: https://stackoverflow.com/questions/41991480/the-new-key-policy-will-not-allow-you-to-update-the-key-policy-in-the-future
+  # Resource – (Required) In a key policy, you use "*" for the resource, which means "this CMK."
+  # A key policy applies only to the CMK it is attached to.
   statement {
     sid    = "AllowKMSAllAccess"
     effect = "Allow"
@@ -16,7 +20,7 @@ data "aws_iam_policy_document" "cloudfront_policies" {
     ]
 
     resources = [
-      "arn:aws:kms:::key/*",
+      "*",
     ]
   }
 
@@ -40,7 +44,7 @@ data "aws_iam_policy_document" "cloudfront_policies" {
     ]
 
     resources = [
-      "arn:aws:kms:::key/*",
+      "*",
     ]
 
     condition {


### PR DESCRIPTION
@sylviamclaughlin I think I found out what the issue is. FYI, I haven't run apply manually yet.

The issue appears to be for CMK, resources must be set to "*", which checkov dislikes.

The AWS documentation does not talk about this. However, per [stackoverflow](https://stackoverflow.com/questions/41991480/the-new-key-policy-will-not-allow-you-to-update-the-key-policy-in-the-future):

The Resource: "*" [is required and is the only possible value](http://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html):

Resource – (Required) In a key policy, you use "*" for the resource, which means "this CMK." A key policy applies only to the CMK it is attached to.

See https://aws.amazon.com/premiumsupport/knowledge-center/update-key-policy-future/ for an example.