### PR TITLE
Fix/kms policy typo, resources region

### DIFF
--- a/terragrunt/aws/cloudfront/iam.tf
+++ b/terragrunt/aws/cloudfront/iam.tf
@@ -31,7 +31,7 @@ data "aws_iam_policy_document" "cloudfront_policies" {
 
     principals {
       identifiers = [
-        "logs.${var.region}.amazonaws.com",
+        "logs.us-east-1.amazonaws.com",
       ]
       type = "Service"
     }
@@ -47,13 +47,5 @@ data "aws_iam_policy_document" "cloudfront_policies" {
     resources = [
       "*",
     ]
-
-    condition {
-      test     = "ArnEquals"
-      variable = "kms:EncryptionContext:aws:logs:arn"
-      values = [
-        "arn:aws:logs:${var.region}:${var.account_id}:log-group:aws-waf-logs-${var.product_name}",
-      ]
-    }
   }
 }

--- a/terragrunt/aws/cloudfront/iam.tf
+++ b/terragrunt/aws/cloudfront/iam.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "cloudfront_policies" {
       test     = "ArnEquals"
       variable = "kms:EncryptionContext:aws:logs:arn"
       values = [
-        "arn:aws:logs:${var.region}:${var.account_id}:log-group:aws-waf-logs-${var.product_name}/",
+        "arn:aws:logs:${var.region}:${var.account_id}:log-group:aws-waf-logs-${var.product_name}",
       ]
     }
   }

--- a/terragrunt/aws/cloudfront/waf.tf
+++ b/terragrunt/aws/cloudfront/waf.tf
@@ -266,7 +266,6 @@ resource "aws_wafv2_regex_pattern_set" "valid_uri_paths" {
 
 resource "aws_kms_key" "wafv2-log-group-kms-key" {
   provider                 = aws.us-east-1
-
   description              = "WAF Cloudwatch logs KMS key"
   key_usage                = "ENCRYPT_DECRYPT"
   customer_master_key_spec = "SYMMETRIC_DEFAULT"
@@ -281,8 +280,7 @@ resource "aws_kms_key" "wafv2-log-group-kms-key" {
 }
 
 resource "aws_cloudwatch_log_group" "wafv2-log-group" {
-  provider = aws.us-east-1
-
+  provider          = aws.us-east-1
   name              = "aws-waf-logs-${var.product_name}"
   retention_in_days = 90
   kms_key_id        = aws_kms_key.wafv2-log-group-kms-key.arn
@@ -294,16 +292,14 @@ resource "aws_cloudwatch_log_group" "wafv2-log-group" {
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "waf_logging_configuration" {
-  provider = aws.us-east-1
-
+  provider                = aws.us-east-1
   log_destination_configs = [aws_cloudwatch_log_group.wafv2-log-group.arn]
   resource_arn            = aws_wafv2_web_acl.api_waf.arn
   depends_on              = [aws_cloudwatch_log_group.wafv2-log-group]
 }
 
 resource "aws_cloudwatch_log_metric_filter" "wafv2-log-metric-filter" {
-  provider = aws.us-east-1
-
+  provider       = aws.us-east-1
   name           = "aws-waf-logs-${var.product_name}-metric-filter"
   pattern        = "{ $.httpRequest.uri != \"/version\" }"
   log_group_name = aws_cloudwatch_log_group.wafv2-log-group.name
@@ -316,8 +312,7 @@ resource "aws_cloudwatch_log_metric_filter" "wafv2-log-metric-filter" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "wafv2-log-metric-filter-health-check" {
-  provider = aws.us-east-1
-
+  provider       = aws.us-east-1
   name           = "aws-waf-logs-${var.product_name}-metric-filter-health-check"
   pattern        = "{ $.httpRequest.uri = \"/version\" }"
   log_group_name = aws_cloudwatch_log_group.wafv2-log-group.name

--- a/terragrunt/aws/cloudfront/waf.tf
+++ b/terragrunt/aws/cloudfront/waf.tf
@@ -265,6 +265,8 @@ resource "aws_wafv2_regex_pattern_set" "valid_uri_paths" {
 }
 
 resource "aws_kms_key" "wafv2-log-group-kms-key" {
+  provider                 = aws.us-east-1
+
   description              = "WAF Cloudwatch logs KMS key"
   key_usage                = "ENCRYPT_DECRYPT"
   customer_master_key_spec = "SYMMETRIC_DEFAULT"
@@ -279,6 +281,8 @@ resource "aws_kms_key" "wafv2-log-group-kms-key" {
 }
 
 resource "aws_cloudwatch_log_group" "wafv2-log-group" {
+  provider = aws.us-east-1
+
   name              = "aws-waf-logs-${var.product_name}"
   retention_in_days = 90
   kms_key_id        = aws_kms_key.wafv2-log-group-kms-key.arn
@@ -290,6 +294,9 @@ resource "aws_cloudwatch_log_group" "wafv2-log-group" {
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "waf_logging_configuration" {
+  provider = aws.us-east-1
+
   log_destination_configs = [aws_cloudwatch_log_group.wafv2-log-group.arn]
   resource_arn            = aws_wafv2_web_acl.api_waf.arn
+  depends_on              = [aws_cloudwatch_log_group.wafv2-log-group]
 }

--- a/terragrunt/aws/cloudfront/waf.tf
+++ b/terragrunt/aws/cloudfront/waf.tf
@@ -300,3 +300,31 @@ resource "aws_wafv2_web_acl_logging_configuration" "waf_logging_configuration" {
   resource_arn            = aws_wafv2_web_acl.api_waf.arn
   depends_on              = [aws_cloudwatch_log_group.wafv2-log-group]
 }
+
+resource "aws_cloudwatch_log_metric_filter" "wafv2-log-metric-filter" {
+  provider = aws.us-east-1
+
+  name           = "aws-waf-logs-${var.product_name}-metric-filter"
+  pattern        = "{ $.httpRequest.uri != \"/version\" }"
+  log_group_name = aws_cloudwatch_log_group.wafv2-log-group.name
+
+  metric_transformation {
+    name      = "RequestCount"
+    namespace = "UserTraffic"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "wafv2-log-metric-filter-health-check" {
+  provider = aws.us-east-1
+
+  name           = "aws-waf-logs-${var.product_name}-metric-filter-health-check"
+  pattern        = "{ $.httpRequest.uri = \"/version\" }"
+  log_group_name = aws_cloudwatch_log_group.wafv2-log-group.name
+
+  metric_transformation {
+    name      = "RequestCount"
+    namespace = "HealthCheckTraffic"
+    value     = "1"
+  }
+}


### PR DESCRIPTION
@sylviamclaughlin This fixes the tf apply issues. The logging resources must be in `us-east-1`. I still need to refine the metric filters a bit. It's too noisy because of the health check probes. I will do this in a separate PR.

Can you review?