### PR TITLE
Enabling TTL for the dynamoDB table

### DIFF
--- a/terragrunt/aws/dynamodb/url_shortener_table.tf
+++ b/terragrunt/aws/dynamodb/url_shortener_table.tf
@@ -19,7 +19,7 @@ resource "aws_dynamodb_table" "url_shortener" {
 
   ttl {
     attribute_name = "ttl"
-    enabled        = true 
+    enabled        = true
   }
 
   tags = {

--- a/terragrunt/aws/dynamodb/url_shortener_table.tf
+++ b/terragrunt/aws/dynamodb/url_shortener_table.tf
@@ -19,7 +19,7 @@ resource "aws_dynamodb_table" "url_shortener" {
 
   ttl {
     attribute_name = "ttl"
-    enabled        = false
+    enabled        = true 
   }
 
   tags = {


### PR DESCRIPTION
# Summary | Résumé

I had the ttl value previously disabled, which I am fixing now. 