### PR TITLE
fix: index permissions

### DIFF
--- a/terragrunt/aws/api/iam.tf
+++ b/terragrunt/aws/api/iam.tf
@@ -13,7 +13,8 @@ data "aws_iam_policy_document" "api_policies" {
     ]
 
     resources = [
-      "arn:aws:dynamodb:${var.region}:${var.account_id}:table/${var.url_shortener_table_name}"
+      "arn:aws:dynamodb:${var.region}:${var.account_id}:table/${var.url_shortener_table_name}",
+      "arn:aws:dynamodb:${var.region}:${var.account_id}:table/${var.url_shortener_table_name}/index/emailIndex",
     ]
   }
 


### PR DESCRIPTION
This PR allows the IAM user to access the correct index on the dynamodb table