### PR TITLE
fix: move lambda specific deps to Dockerfile

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -21,6 +21,9 @@ RUN apk add --no-cache \
 
 RUN wget https://github.com/aws/aws-lambda-runtime-interface-emulator/releases/download/${RIE_VERSION}/aws-lambda-rie
 
+RUN mkdir -p /pymodules \
+    && pip install awscli awslambdaric --target /pymodules
+
 COPY ./requirements.txt /
 RUN pip install -r /requirements.txt --target /pymodules
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,6 +1,4 @@
 advocate==1.0.0
-awscli==1.27.106
-awslambdaric==2.0.4
 boto3==1.26.99
 fastapi==0.95.0
 Jinja2==3.1.2


### PR DESCRIPTION
# Summary
Update the Dockerfile and requirements.txt file to move the dependencies needed for Lambda only into the Dockerfile.