### PR TITLE
fix: word break

### DIFF
--- a/api/static/css/styles.css
+++ b/api/static/css/styles.css
@@ -91,6 +91,7 @@ body {
 
 .link_container {
   background-color: rgb(245, 241, 241);
-  border-color: grey 2px solid;
+  border: rgb(183, 183, 183) 2px solid;
   padding: 15px;
+  word-break: break-all;
 }


### PR DESCRIPTION
Closes #225. Adds CSS word-break to wrap URLs.

<img width="962" alt="Screenshot 2023-04-05 at 6 27 54 PM" src="https://user-images.githubusercontent.com/867334/230225593-6eae8558-a911-4f40-9c5c-aad012f6e7ef.png">
