### PR TITLE
fix: WAF and CloudFront for i18n

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,8 @@
 	"service": "app",
 	"workspaceFolder": "/workspace",
 	"remoteEnv": {
-		"PATH": "/home/vscode/.local/bin:${containerEnv:PATH}" // give our installed Python modules precedence
+		"PATH": "/home/vscode/.local/bin:${containerEnv:PATH}", // give our installed Python modules precedence,
+		"PYTHONPATH": "./api"
 	},	
 	"containerEnv": {
 		"SHELL": "/bin/zsh"

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -16,7 +16,7 @@ module "url_shortener_lambda" {
 
   environment_variables = {
     ALLOWED_DOMAINS            = "canada.ca,gc.ca,cds-snc.ca"
-    NOTIFY_MAGIC_LINK_TEMPLATE = "c8520014-597f-4e73-8eef-baf3f5835596"
+    NOTIFY_MAGIC_LINK_TEMPLATE = "092f910a-c3cd-4a91-901d-a2d93fe1e603"
     SHORTENER_DOMAIN           = "https://${var.domain}/"
     SHORTENER_PATH_LENGTH      = var.shortener_path_length
   }

--- a/terragrunt/aws/cloudfront/cloudfront.tf
+++ b/terragrunt/aws/cloudfront/cloudfront.tf
@@ -84,7 +84,7 @@ resource "aws_cloudfront_response_headers_policy" "security_headers_api" {
       override = true
     }
     content_security_policy {
-      content_security_policy = "report-uri https://csp-report-to.security.cdssandbox.xyz/report; default-src 'none'; script-src 'self' 'unsafe-inline' https://unpkg.com/@cdssnc/ https://${var.domain}/static/js/ https://kit.fontawesome.com; font-src 'self' https://kit.fontawesome.com https://fonts.googleapis.com https://fonts.gstatic.com; connect-src 'self'; img-src 'self' https://${var.domain}/static/img/ http://www.w3.org/2000; style-src 'self' 'unsafe-inline' https://${var.domain}/static/css/ https://unpkg.com/@cdssnc/ https://kit.fontawesome.com https://fonts.googleapis.com; frame-ancestors 'self'; form-action 'self';"
+      content_security_policy = "report-uri https://csp-report-to.security.cdssandbox.xyz/report; default-src 'none'; script-src 'self' https://unpkg.com/@cdssnc/ https://${var.domain}/static/js/ https://kit.fontawesome.com; font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com https://kit.fontawesome.com https://ka-f.fontawesome.com https://unpkg.com/font-awesome@4.7.0/; connect-src 'self' https://ka-f.fontawesome.com; img-src 'self' https://${var.domain}/static/img/ data: w3.org/svg/2000; style-src 'self' 'unsafe-inline' https://${var.domain}/static/css/ https://unpkg.com/@cdssnc/ https://unpkg.com/font-awesome/ https://kit.fontawesome.com https://fonts.googleapis.com; frame-ancestors 'self'; form-action 'self';"
       override                = false
     }
     referrer_policy {

--- a/terragrunt/aws/cloudfront/waf.tf
+++ b/terragrunt/aws/cloudfront/waf.tf
@@ -301,7 +301,7 @@ resource "aws_wafv2_regex_pattern_set" "valid_uri_paths" {
 
   # allow homepage 
   regular_expression {
-    regex_string = "^/$"
+    regex_string = "^/?(en|fr)?$"
   }
 
   # allow static files 
@@ -309,9 +309,19 @@ resource "aws_wafv2_regex_pattern_set" "valid_uri_paths" {
     regex_string = "^/static/*"
   }
 
-  # allow magic_link related pages
+  # allow english paths
   regular_expression {
-    regex_string = "^/(login|logout|magic_link*)$"
+    regex_string = "^/en/(login|logout|magic-link*)$"
+  }
+
+  # allow french paths
+  regular_expression {
+    regex_string = "^/fr/(connexion|deconnexion|lien-magique*)$"
+  }
+
+  # allow lang swap
+  regular_expression {
+    regex_string = "^/lang/(en|fr)$"
   }
 
   tags = {


### PR DESCRIPTION
# Summary
1. Update the WAF regex rules with the new localized paths.
1. Update the CloudFront CSP with the new Fontawesome icons. 
1. Update the magic link Notify template.
1. Add the `./api` folder to the devcontainer's PYTHONPATH to fix import errors.