### PR TITLE
fix: allow API to update DynamoDB items

### DIFF
--- a/terragrunt/aws/api/iam.tf
+++ b/terragrunt/aws/api/iam.tf
@@ -8,7 +8,7 @@ data "aws_iam_policy_document" "api_policies" {
       "dynamodb:DeleteItem",
       "dynamodb:DescribeTable",
       "dynamodb:GetItem",
-      "dynamodb:PutItem",      
+      "dynamodb:PutItem",
       "dynamodb:Query",
       "dynamodb:UpdateItem",
     ]


### PR DESCRIPTION
# Summary
Update the API's lambda function IAM policy to allow it to update DDB items.  This is used to update
the `click_count` of links when they are retrieved.

# ⚠️  Note
These were clickops'd to test.