### PR TITLE
feat: loadtesting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
 	"remoteEnv": {
 		"PATH": "/home/vscode/.local/bin:${containerEnv:PATH}", // give our installed Python modules precedence,
 		"PYTHONPATH": "./api"
-	},	
+	},
 	"containerEnv": {
 		"SHELL": "/bin/zsh"
 	},
@@ -45,6 +45,7 @@
 		"ghcr.io/devcontainers/features/aws-cli:1": {},
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/node:1": {},
+		"ghcr.io/dhoeric/features/k6:1": {},
 		"terraform": {
 			"version": "1.3.7",
 			"tflint": "latest",

--- a/.github/workflows/cypress_e2e.yml
+++ b/.github/workflows/cypress_e2e.yml
@@ -24,6 +24,21 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Create DB
+        run: |
+          aws dynamodb create-table \
+            --table-name url_shortener \
+            --attribute-definitions AttributeName=key_id,AttributeType=S AttributeName=email,AttributeType=S \
+            --key-schema AttributeName=key_id,KeyType=HASH \
+            --global-secondary-indexes IndexName=emailIndex,KeySchema=["{AttributeName=email,KeyType=HASH}"],Projection="{ProjectionType=ALL}",ProvisionedThroughput="{ReadCapacityUnits=1,WriteCapacityUnits=1}" \
+            --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1 \
+            --endpoint-url http://localhost:9000 \
+            --no-cli-pager \
+        env:
+          AWS_ACCESS_KEY_ID: 'AWS_ACCESS_KEY_ID'
+          AWS_SECRET_ACCESS_KEY: 'AWS_SECRET_ACCESS_KEY'
+          AWS_REGION: 'ca-central-1'
+
       - name: Install dev dependencies
         working-directory: ./api
         run: make install-dev
@@ -49,4 +64,3 @@ jobs:
           NOTIFY_MAGIC_LINK_TEMPLATE: ""
           SHORTENER_DOMAIN: "http://127.0.0.1:8000/"
           SHORTENER_PATH_LENGTH: "6"
-          TABLE_NAME: "url_shortener_test"

--- a/.github/workflows/loadtesting.yml
+++ b/.github/workflows/loadtesting.yml
@@ -51,10 +51,10 @@ jobs:
           AWS_ACCESS_KEY_ID: "AWS_ACCESS_KEY_ID"
           AWS_SECRET_ACCESS_KEY: "AWS_SECRET_ACCESS_KEY"
           AWS_REGION: "ca-central-1"
-          CYPRESS_CI: "true"
           DYNAMODB_HOST: "http://localhost:9000"
           NOTIFY_API_KEY: ""
           NOTIFY_MAGIC_LINK_TEMPLATE: ""
+          PEPPERS: 'ejp8zh0QHl1BKPMvH4d9zFvS1rkbnYz9uqaEae9uwmY=,fwNAF1u7dA3j0YtsOoHtE0wIzCisSyzqTOhI4TkG5dA=,W2ktstHWiB1+UJLku8Mi0f1Su5RhX+p7hx7UxsrNVOE=,QIPgZU1zZ/tdLAigsLPl4j1zQ8Yc2rUMrVrSMTnZwlM=,sUUmk4x4tgVvfAxM9cu/ZCeIL88SJefJYFkZcHERYEY='
           SHORTENER_DOMAIN: "http://127.0.0.1:8000/"
           SHORTENER_PATH_LENGTH: "6"
           TABLE_NAME: "url_shortener_test"

--- a/.github/workflows/loadtesting.yml
+++ b/.github/workflows/loadtesting.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           curl -L https://github.com/grafana/k6/releases/download/v0.43.1/k6-v0.43.1-linux-amd64.tar.gz -o k6.tar.gz
           tar -xzf k6.tar.gz
-          sudo mv k6-*/ /usr/local/bin
+          sudo mv k6-*/k6 /usr/local/bin
 
       - name: Run load testing
         working-directory: ./api

--- a/.github/workflows/loadtesting.yml
+++ b/.github/workflows/loadtesting.yml
@@ -1,0 +1,59 @@
+name: Load testing
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - api/**
+      - .github/workflows/loadtesting.yml
+
+jobs:
+  load_testing:
+    runs-on: ubuntu-latest
+    services:
+      dynamodb-local:
+        image: "amazon/dynamodb-local"
+        ports:
+          - 9000:8000
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+
+      - name: Setup python
+        uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
+        with:
+          python-version: "3.11"
+
+      - name: Install dev dependencies
+        working-directory: ./api
+        run: make install-dev
+
+      - name: Install dependencies
+        working-directory: ./api
+        run: make install
+
+      - name: Download k6
+        run: |
+          curl -L https://github.com/grafana/k6/releases/download/v0.43.1/k6-v0.43.1-linux-amd64.tar.gz -o k6.tar.gz
+          tar -xzf k6.tar.gz
+          sudo mv k6 /usr/local/bin
+
+      - name: Run load testing
+        working-directory: ./api
+        run: |
+          nohup make dev &
+          k6 run ./loadtesting/test.js
+        env:
+          ALLOWED_DOMAINS: "canada.ca,gc.ca"
+          AUTH_TOKEN_APP: "auth_token_app"
+          AUTH_TOKEN_NOTIFY: "auth_token_notify"
+          AWS_ACCESS_KEY_ID: "AWS_ACCESS_KEY_ID"
+          AWS_SECRET_ACCESS_KEY: "AWS_SECRET_ACCESS_KEY"
+          AWS_REGION: "ca-central-1"
+          CYPRESS_CI: "true"
+          DYNAMODB_HOST: "http://localhost:9000"
+          NOTIFY_API_KEY: ""
+          NOTIFY_MAGIC_LINK_TEMPLATE: ""
+          SHORTENER_DOMAIN: "http://127.0.0.1:8000/"
+          SHORTENER_PATH_LENGTH: "6"
+          TABLE_NAME: "url_shortener_test"

--- a/.github/workflows/loadtesting.yml
+++ b/.github/workflows/loadtesting.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Run load testing
         working-directory: ./api
         run: |
-          nohup make dev &
+          nohup make e2e-dev &
           sleep 5
           make loadtest
         env:

--- a/.github/workflows/loadtesting.yml
+++ b/.github/workflows/loadtesting.yml
@@ -68,6 +68,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: "AWS_SECRET_ACCESS_KEY"
           AWS_REGION: "ca-central-1"
           DYNAMODB_HOST: "http://localhost:9000"
+          ENVIRONMENT: "ci"
           NOTIFY_API_KEY: ""
           NOTIFY_MAGIC_LINK_TEMPLATE: ""
           PEPPERS: 'ejp8zh0QHl1BKPMvH4d9zFvS1rkbnYz9uqaEae9uwmY=,fwNAF1u7dA3j0YtsOoHtE0wIzCisSyzqTOhI4TkG5dA=,W2ktstHWiB1+UJLku8Mi0f1Su5RhX+p7hx7UxsrNVOE=,QIPgZU1zZ/tdLAigsLPl4j1zQ8Yc2rUMrVrSMTnZwlM=,sUUmk4x4tgVvfAxM9cu/ZCeIL88SJefJYFkZcHERYEY='

--- a/.github/workflows/loadtesting.yml
+++ b/.github/workflows/loadtesting.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           curl -L https://github.com/grafana/k6/releases/download/v0.43.1/k6-v0.43.1-linux-amd64.tar.gz -o k6.tar.gz
           tar -xzf k6.tar.gz
-          sudo mv k6 /usr/local/bin
+          sudo mv k6-*/ /usr/local/bin
 
       - name: Run load testing
         working-directory: ./api

--- a/.github/workflows/loadtesting.yml
+++ b/.github/workflows/loadtesting.yml
@@ -73,4 +73,3 @@ jobs:
           PEPPERS: 'ejp8zh0QHl1BKPMvH4d9zFvS1rkbnYz9uqaEae9uwmY=,fwNAF1u7dA3j0YtsOoHtE0wIzCisSyzqTOhI4TkG5dA=,W2ktstHWiB1+UJLku8Mi0f1Su5RhX+p7hx7UxsrNVOE=,QIPgZU1zZ/tdLAigsLPl4j1zQ8Yc2rUMrVrSMTnZwlM=,sUUmk4x4tgVvfAxM9cu/ZCeIL88SJefJYFkZcHERYEY='
           SHORTENER_DOMAIN: "http://127.0.0.1:8000/"
           SHORTENER_PATH_LENGTH: "6"
-          TABLE_NAME: "url_shortener_test"

--- a/.github/workflows/loadtesting.yml
+++ b/.github/workflows/loadtesting.yml
@@ -68,7 +68,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: "AWS_SECRET_ACCESS_KEY"
           AWS_REGION: "ca-central-1"
           DYNAMODB_HOST: "http://localhost:9000"
-          ENVIRONMENT: "ci"
+          ENV: "ci"
           NOTIFY_API_KEY: ""
           NOTIFY_MAGIC_LINK_TEMPLATE: ""
           PEPPERS: 'ejp8zh0QHl1BKPMvH4d9zFvS1rkbnYz9uqaEae9uwmY=,fwNAF1u7dA3j0YtsOoHtE0wIzCisSyzqTOhI4TkG5dA=,W2ktstHWiB1+UJLku8Mi0f1Su5RhX+p7hx7UxsrNVOE=,QIPgZU1zZ/tdLAigsLPl4j1zQ8Yc2rUMrVrSMTnZwlM=,sUUmk4x4tgVvfAxM9cu/ZCeIL88SJefJYFkZcHERYEY='

--- a/.github/workflows/loadtesting.yml
+++ b/.github/workflows/loadtesting.yml
@@ -72,4 +72,4 @@ jobs:
           NOTIFY_MAGIC_LINK_TEMPLATE: ""
           PEPPERS: 'ejp8zh0QHl1BKPMvH4d9zFvS1rkbnYz9uqaEae9uwmY=,fwNAF1u7dA3j0YtsOoHtE0wIzCisSyzqTOhI4TkG5dA=,W2ktstHWiB1+UJLku8Mi0f1Su5RhX+p7hx7UxsrNVOE=,QIPgZU1zZ/tdLAigsLPl4j1zQ8Yc2rUMrVrSMTnZwlM=,sUUmk4x4tgVvfAxM9cu/ZCeIL88SJefJYFkZcHERYEY='
           SHORTENER_DOMAIN: "http://127.0.0.1:8000/"
-          SHORTENER_PATH_LENGTH: "6"
+          SHORTENER_PATH_LENGTH: "8"

--- a/.github/workflows/loadtesting.yml
+++ b/.github/workflows/loadtesting.yml
@@ -24,6 +24,18 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Create DB
+        run: |
+          aws dynamodb create-table \
+          --table-name url_shortener \
+          --attribute-definitions AttributeName=key_id,AttributeType=S AttributeName=email,AttributeType=S \
+          --key-schema AttributeName=key_id,KeyType=HASH \
+          --global-secondary-indexes IndexName=emailIndex,KeySchema=["{AttributeName=email,KeyType=HASH}"],Projection="{ProjectionType=ALL}",ProvisionedThroughput="{ReadCapacityUnits=1,WriteCapacityUnits=1}" \
+          --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1 \
+          --endpoint-url http://localhost:9000 \
+          --no-cli-pager \
+     
+
       - name: Install dev dependencies
         working-directory: ./api
         run: make install-dev

--- a/.github/workflows/loadtesting.yml
+++ b/.github/workflows/loadtesting.yml
@@ -34,6 +34,10 @@ jobs:
             --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1 \
             --endpoint-url http://localhost:9000 \
             --no-cli-pager \
+        env:
+          AWS_ACCESS_KEY_ID: 'AWS_ACCESS_KEY_ID'
+          AWS_SECRET_ACCESS_KEY: 'AWS_SECRET_ACCESS_KEY'
+          AWS_REGION: 'ca-central-1'
      
 
       - name: Install dev dependencies

--- a/.github/workflows/loadtesting.yml
+++ b/.github/workflows/loadtesting.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           nohup make dev &
           sleep 5
-          k6 run ./loadtesting/test.js
+          make loadtest
         env:
           ALLOWED_DOMAINS: "canada.ca,gc.ca"
           AUTH_TOKEN_APP: "auth_token_app"

--- a/.github/workflows/loadtesting.yml
+++ b/.github/workflows/loadtesting.yml
@@ -27,13 +27,13 @@ jobs:
       - name: Create DB
         run: |
           aws dynamodb create-table \
-          --table-name url_shortener \
-          --attribute-definitions AttributeName=key_id,AttributeType=S AttributeName=email,AttributeType=S \
-          --key-schema AttributeName=key_id,KeyType=HASH \
-          --global-secondary-indexes IndexName=emailIndex,KeySchema=["{AttributeName=email,KeyType=HASH}"],Projection="{ProjectionType=ALL}",ProvisionedThroughput="{ReadCapacityUnits=1,WriteCapacityUnits=1}" \
-          --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1 \
-          --endpoint-url http://localhost:9000 \
-          --no-cli-pager \
+            --table-name url_shortener \
+            --attribute-definitions AttributeName=key_id,AttributeType=S AttributeName=email,AttributeType=S \
+            --key-schema AttributeName=key_id,KeyType=HASH \
+            --global-secondary-indexes IndexName=emailIndex,KeySchema=["{AttributeName=email,KeyType=HASH}"],Projection="{ProjectionType=ALL}",ProvisionedThroughput="{ReadCapacityUnits=1,WriteCapacityUnits=1}" \
+            --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1 \
+            --endpoint-url http://localhost:9000 \
+            --no-cli-pager \
      
 
       - name: Install dev dependencies

--- a/.github/workflows/loadtesting.yml
+++ b/.github/workflows/loadtesting.yml
@@ -42,6 +42,7 @@ jobs:
         working-directory: ./api
         run: |
           nohup make dev &
+          sleep 5
           k6 run ./loadtesting/test.js
         env:
           ALLOWED_DOMAINS: "canada.ca,gc.ca"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ curl -X POST http://localhost:8000/v1 \
 {"short_url":"http://127.0.0.1:8000/IcWuXU64","original_url":"https://digital.canada.ca","status":"OK"}
 ```
 
-
 ### Running end-to-end and accessbility tests using Cypress
 
 You can run end-to-end tests by doing the following:
@@ -84,3 +83,10 @@ You can run end-to-end tests by doing the following:
 2. Run `make e2e` to start a docker container that has cypress installed as well as the `cypress-axe` extension for the `axe-core` package.
 
 Videos and screenshots of the test runs can be found in `./api/e2e/cypress/screenshots|videos` folder.
+
+### Loadtesting
+
+We currently use k6 to run our loadtests. Assuming you are in the devcontainer:
+
+1. Start the dev server locally, ex: `make e2e-dev` in the `./api` folder.
+2. Run `make loadtest` to start the test script in `./api/loadtesting/test.js`

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev e2e e2e-ci e2e-dev fmt install lint test fmt-ci lint-ci install-dev
+.PHONY: dev e2e e2e-ci e2e-dev fmt install loadtest lint test fmt-ci lint-ci install-dev
 
 dev:
 	@export $$(xargs < .env) > /dev/null &&\
@@ -34,6 +34,9 @@ install:
 
 install-dev:
 	pip3 install --user -r requirements_dev.txt
+
+loadtest:
+	k6 run ./loadtesting/test.js
 
 lint:
 	flake8 .

--- a/api/loadtesting/test.js
+++ b/api/loadtesting/test.js
@@ -3,7 +3,7 @@ import { sleep } from 'k6';
 
 export const options = {
   duration: '1m',
-  vus: 100,
+  vus: 20,
   thresholds: {
     http_req_failed: ['rate<0.01'], // http errors should be less than 1%
     http_req_duration: ['p(95)<500'], // 95 percent of response times must be below 500ms
@@ -11,7 +11,9 @@ export const options = {
 };
 
 export default function () {
-
-  const res = http.get('http://127.0.0.1:8000/foobar');
+  const get_resp = http.get('http://127.0.0.1:8000/foobar');
+  sleep(1);
+  const data = JSON.stringify({ "original_url": "https://digital.canada.ca" })
+  const post_resp = http.post('http://127.0.0.1:8000/v1', data, { headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer auth_token_app' } });
   sleep(1);
 }

--- a/api/loadtesting/test.js
+++ b/api/loadtesting/test.js
@@ -2,7 +2,7 @@ import http from 'k6/http';
 import { sleep } from 'k6';
 
 export const options = {
-  duration: '1m',
+  duration: '10s',
   vus: 20,
   thresholds: {
     'http_req_failed{name:redirectPage}': ['rate<0.01'], // http errors should be less than 1%
@@ -13,7 +13,7 @@ export const options = {
 };
 
 export default function () {
-  http.get('http://0.0.0.0:8000/foobared', { tags: { name: 'redirectPage' } });
+  http.get('http://0.0.0.0:8000/foobar', { tags: { name: 'redirectPage' } });
 
   sleep(1);
 
@@ -26,6 +26,7 @@ export default function () {
     tags: { name: 'createShortUrl' }
   }
 
-  http.post('http://0.0.0.0:8000/v1', data, params);
+  const res = http.post('http://0.0.0.0:8000/v1', data, params);
+  console.log(res.body);
   sleep(1);
 };

--- a/api/loadtesting/test.js
+++ b/api/loadtesting/test.js
@@ -7,7 +7,7 @@ const ENVIROMENT = __ENV.ENV || 'dev';
 const profiles = {
   ci: {
     host: 'http://0.0.0.0:8000/',
-    createShortUrlVus: 5,
+    createShortUrlVus: 10,
     duration_p95_createShortUrl: '3000',
     redirectPageVus: 100,
     duration_p95_redirectPage: '500',

--- a/api/loadtesting/test.js
+++ b/api/loadtesting/test.js
@@ -8,7 +8,7 @@ const profiles = {
   ci: {
     host: 'http://0.0.0.0:8000/',
     createShortUrlVus: 10,
-    duration_p95_createShortUrl: '2000',
+    duration_p95_createShortUrl: '3000',
     redirectPageVus: 100,
     duration_p95_redirectPage: '500',
   },
@@ -26,7 +26,6 @@ const profiles = {
     redirectPageVus: 100,
     duration_p95_redirectPage: '500',
   },
-
 }
 
 export const options = {

--- a/api/loadtesting/test.js
+++ b/api/loadtesting/test.js
@@ -15,7 +15,7 @@ const profiles = {
   dev: {
     host: 'http://127.0.0.1:8000/',
     createShortUrlVus: 25,
-    duration_p95_createShortUrl: '1000',
+    duration_p95_createShortUrl: '1500',
     redirectPageVus: 100,
     duration_p95_redirectPage: '500',
   },

--- a/api/loadtesting/test.js
+++ b/api/loadtesting/test.js
@@ -7,7 +7,7 @@ const ENVIROMENT = __ENV.ENV || 'dev';
 const profiles = {
   ci: {
     host: 'http://0.0.0.0:8000/',
-    createShortUrlVus: 10,
+    createShortUrlVus: 5,
     duration_p95_createShortUrl: '3000',
     redirectPageVus: 100,
     duration_p95_redirectPage: '500',
@@ -55,6 +55,7 @@ export const options = {
   },
 };
 
+console.log(`Running load test against ${ENVIROMENT} environment`)
 
 export function redirectPage() {
   http.get(`${profiles[ENVIROMENT].host}abcdefgh`, { tags: { name: 'redirectPage' } });

--- a/api/loadtesting/test.js
+++ b/api/loadtesting/test.js
@@ -5,21 +5,27 @@ export const options = {
   duration: '1m',
   vus: 20,
   thresholds: {
-    http_req_failed: ['rate<0.01'], // http errors should be less than 1%
-    http_req_duration: ['p(95)<500'], // 95 percent of response times must be below 500ms
+    'http_req_failed{name:redirectPage}': ['rate<0.01'], // http errors should be less than 1%
+    'http_req_duration{name:redirectPage}': ['p(95)<500'], // 95 percent of response times must be below 500ms
+    'http_req_failed{name:createShortUrl}': ['rate<0.01'], // http errors should be less than 1%
+    'http_req_duration{name:createShortUrl}': ['p(95)<750'], // 95 percent of response times must be below 750ms
   },
 };
 
 export default function () {
-  const get_resp = http.get('http://127.0.0.1:8000/foobar');
+  http.get('http://0.0.0.0:8000/foobared', { tags: { name: 'redirectPage' } });
+
   sleep(1);
+
   const data = JSON.stringify({ "original_url": "https://digital.canada.ca" })
   const params = {
     headers: {
       'Content-Type': 'application/json',
       'Authorization': 'Bearer auth_token_app'
     },
+    tags: { name: 'createShortUrl' }
   }
-  const post_resp = http.post('http://127.0.0.1:8000/v1', data, params);
+
+  http.post('http://0.0.0.0:8000/v1', data, params);
   sleep(1);
-}
+};

--- a/api/loadtesting/test.js
+++ b/api/loadtesting/test.js
@@ -1,22 +1,42 @@
 import http from 'k6/http';
 import { sleep } from 'k6';
 
+const HOST = __ENV.SHORTENER_DOMAIN || 'http://0.0.0.0:8000/';
+
 export const options = {
-  duration: '30s',
-  vus: 100,
+  discardResponseBodies: true,
+  scenarios: {
+    createShortUrl: {
+      executor: 'constant-vus',
+      exec: 'createShortUrl',
+      vus: 50,
+      duration: '30s',
+      gracefulStop: '0s',
+    },
+    redirectPage: {
+      executor: 'constant-vus',
+      exec: 'redirectPage',
+      vus: 100,
+      duration: '30s',
+      gracefulStop: '0s',
+      startTime: '30s',
+    },
+  },
   thresholds: {
     'http_req_failed{name:redirectPage}': ['rate<0.01'], // http errors should be less than 1%
     'http_req_duration{name:redirectPage}': ['p(95)<500'], // 95 percent of response times must be below 500ms
     'http_req_failed{name:createShortUrl}': ['rate<0.01'], // http errors should be less than 1%
-    'http_req_duration{name:createShortUrl}': ['p(95)<2500'], // 95 percent of response times must be below 2500ms
+    'http_req_duration{name:createShortUrl}': ['p(95)<2500'], // 95 percent of response times must be below 2000ms
   },
 };
 
-export default function () {
-  http.get('http://0.0.0.0:8000/foobar', { tags: { name: 'redirectPage' } });
 
+export function redirectPage() {
+  http.get(`${HOST}abcdefgh`, { tags: { name: 'redirectPage' } });
   sleep(1);
+}
 
+export function createShortUrl() {
   const data = JSON.stringify({ "original_url": "https://digital.canada.ca" })
   const params = {
     headers: {
@@ -26,6 +46,6 @@ export default function () {
     tags: { name: 'createShortUrl' }
   }
 
-  http.post('http://0.0.0.0:8000/v1', data, params);
+  http.post(`${HOST}v1`, data, params);
   sleep(1);
-};
+}

--- a/api/loadtesting/test.js
+++ b/api/loadtesting/test.js
@@ -26,6 +26,7 @@ export default function () {
     tags: { name: 'createShortUrl' }
   }
 
-  http.post('http://0.0.0.0:8000/v1', data, params);
+  const res = http.post('http://0.0.0.0:8000/v1', data, params);
+  console.log(res.body);
   sleep(1);
 };

--- a/api/loadtesting/test.js
+++ b/api/loadtesting/test.js
@@ -3,7 +3,7 @@ import { sleep } from 'k6';
 
 export const options = {
   duration: '1m',
-  vus: 5,
+  vus: 20,
   thresholds: {
     http_req_failed: ['rate<0.01'], // http errors should be less than 1%
     http_req_duration: ['p(95)<500'], // 95 percent of response times must be below 500ms

--- a/api/loadtesting/test.js
+++ b/api/loadtesting/test.js
@@ -2,13 +2,13 @@ import http from 'k6/http';
 import { sleep } from 'k6';
 
 export const options = {
-  duration: '10s',
-  vus: 20,
+  duration: '30s',
+  vus: 100,
   thresholds: {
     'http_req_failed{name:redirectPage}': ['rate<0.01'], // http errors should be less than 1%
     'http_req_duration{name:redirectPage}': ['p(95)<500'], // 95 percent of response times must be below 500ms
     'http_req_failed{name:createShortUrl}': ['rate<0.01'], // http errors should be less than 1%
-    'http_req_duration{name:createShortUrl}': ['p(95)<750'], // 95 percent of response times must be below 750ms
+    'http_req_duration{name:createShortUrl}': ['p(95)<2500'], // 95 percent of response times must be below 2500ms
   },
 };
 
@@ -26,7 +26,6 @@ export default function () {
     tags: { name: 'createShortUrl' }
   }
 
-  const res = http.post('http://0.0.0.0:8000/v1', data, params);
-  console.log(res.body);
+  http.post('http://0.0.0.0:8000/v1', data, params);
   sleep(1);
 };

--- a/api/loadtesting/test.js
+++ b/api/loadtesting/test.js
@@ -1,0 +1,17 @@
+import http from 'k6/http';
+import { sleep } from 'k6';
+
+export const options = {
+  duration: '1m',
+  vus: 5,
+  thresholds: {
+    http_req_failed: ['rate<0.01'], // http errors should be less than 1%
+    http_req_duration: ['p(95)<500'], // 95 percent of response times must be below 500ms
+  },
+};
+
+export default function () {
+
+  const res = http.get('http://127.0.0.1:8000/foobar');
+  sleep(1);
+}

--- a/api/loadtesting/test.js
+++ b/api/loadtesting/test.js
@@ -26,7 +26,6 @@ export default function () {
     tags: { name: 'createShortUrl' }
   }
 
-  const res = http.post('http://0.0.0.0:8000/v1', data, params);
-  console.log(res.body);
+  http.post('http://0.0.0.0:8000/v1', data, params);
   sleep(1);
 };

--- a/api/loadtesting/test.js
+++ b/api/loadtesting/test.js
@@ -3,7 +3,7 @@ import { sleep } from 'k6';
 
 export const options = {
   duration: '1m',
-  vus: 20,
+  vus: 100,
   thresholds: {
     http_req_failed: ['rate<0.01'], // http errors should be less than 1%
     http_req_duration: ['p(95)<500'], // 95 percent of response times must be below 500ms

--- a/api/loadtesting/test.js
+++ b/api/loadtesting/test.js
@@ -14,6 +14,12 @@ export default function () {
   const get_resp = http.get('http://127.0.0.1:8000/foobar');
   sleep(1);
   const data = JSON.stringify({ "original_url": "https://digital.canada.ca" })
-  const post_resp = http.post('http://127.0.0.1:8000/v1', data, { headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer auth_token_app' } });
+  const params = {
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer auth_token_app'
+    },
+  }
+  const post_resp = http.post('http://127.0.0.1:8000/v1', data, params);
   sleep(1);
 }


### PR DESCRIPTION
Closes #195.

Adds k6 load testing tool. This will simulate different loads of users for one minute who lookup a short URL and also create a short URL using the API. Expected thresholds are

- less than 1% request fail
- 95 percent of response times must be below some reasonable amount of milliseconds based on the hardware that is running the server.

Currently we have three profiles

- `ci` - expected to pass on GitHub Action Runners
- `dev` - expected to pass in a devcontainer
- `staging` - expected to pass against staging.

The profiles look as follows right now:

```
const profiles = {
  ci: {
    host: 'http://0.0.0.0:8000/',
    createShortUrlVus: 10,
    duration_p95_createShortUrl: '2000',
    redirectPageVus: 100,
    duration_p95_redirectPage: '500',
  },
  dev: {
    host: 'http://127.0.0.1:8000/',
    createShortUrlVus: 25,
    duration_p95_createShortUrl: '1000',
    redirectPageVus: 100,
    duration_p95_redirectPage: '500',
  },
  staging: {
    host: 'https://url-shortener.cdssandbox.xyz/',
    createShortUrlVus: 50,
    duration_p95_createShortUrl: '1000',
    redirectPageVus: 100,
    duration_p95_redirectPage: '500',
  },
}
```

Currently we are only testing the `ci` profile as part of CI, but we should open an issue to test `staging` on a nightly basis. This will require some work around creating a redirect URL to test against as it is not running the `CYPRESS_CI` flag and tweaking the load testing script.

The output looks something like this:

<img width="999" alt="Screenshot 2023-04-13 at 1 31 52 PM" src="https://user-images.githubusercontent.com/867334/231838860-311d22fe-8143-40ef-87e0-4728f36acc89.png">
