### PR TITLE
Tweak error messages to make them less noisy when alarming

### DIFF
--- a/api/utils/helpers.py
+++ b/api/utils/helpers.py
@@ -74,7 +74,7 @@ def is_valid_url(original_url):
     try:
         return validators.url(original_url)
     except Exception as err:
-        log.warning(fCould not validate url: {original_url}: {err}")
+        log.warning(f"Could not validate url: {original_url}: {err}")
         return False
 
 

--- a/api/utils/helpers.py
+++ b/api/utils/helpers.py
@@ -74,7 +74,7 @@ def is_valid_url(original_url):
     try:
         return validators.url(original_url)
     except Exception as err:
-        log.warning(f"Error in validating url: {original_url}: {err}")
+        log.warning(fCould not validate url: {original_url}: {err}")
         return False
 
 
@@ -93,7 +93,7 @@ def resolve_short_url(short_url):
         return {"original_url": {"S": "https://digital.canada.ca/"}}
     result = ShortUrls.get_short_url(short_url)
     if result is None:
-        log.warning(f"Error in resolving url: {short_url}")
+        log.warning(f"Could not resolve url: {short_url}")
         return False
     return result
 

--- a/api/utils/helpers.py
+++ b/api/utils/helpers.py
@@ -74,7 +74,7 @@ def is_valid_url(original_url):
     try:
         return validators.url(original_url)
     except Exception as err:
-        log.error(f"Error in validating url: {original_url}: {err}")
+        log.warning(f"Error in validating url: {original_url}: {err}")
         return False
 
 
@@ -93,7 +93,7 @@ def resolve_short_url(short_url):
         return {"original_url": {"S": "https://digital.canada.ca/"}}
     result = ShortUrls.get_short_url(short_url)
     if result is None:
-        log.error(f"Error in resolving url: {short_url}")
+        log.warning(f"Error in resolving url: {short_url}")
         return False
     return result
 
@@ -107,7 +107,7 @@ def return_short_url(original_url, peppers, created_by):
     try:
         advocate.get(original_url)
     except advocate.UnacceptableAddressException:
-        log.error(f"Unacceptable address: {original_url}")
+        log.warning(f"Unacceptable address: {original_url}")
         return {"error": "error_forbidden_resource"}
     except requests.RequestException as err:
         log.error(f"Failed to connect to {original_url}: {err}")

--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_log_metric_filter" "url_shortener_api_error" {
   name           = local.error_logged_api
-  pattern        = "?ERROR ?Error ?error ?failed"
+  pattern        = "{$.levelname=\"ERROR\"}" 
   log_group_name = local.api_cloudwatch_log_group
 
   metric_transformation {

--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_log_metric_filter" "url_shortener_api_error" {
   name           = local.error_logged_api
-  pattern        = "{$.levelname=\"ERROR\"}" 
+  pattern        = "?ERROR ?Error ?error ?failed" 
   log_group_name = local.api_cloudwatch_log_group
 
   metric_transformation {

--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_log_metric_filter" "url_shortener_api_error" {
   name           = local.error_logged_api
-  pattern        = "?ERROR ?Error ?error ?failed" 
+  pattern        = "?ERROR ?Error ?error ?failed"
   log_group_name = local.api_cloudwatch_log_group
 
   metric_transformation {


### PR DESCRIPTION
# Summary | Résumé

Changing some of the error messages from error to warning so that they are less noisy. Moved them from log.error to log.warning, which should make the messages more meaning. The treshold for warning is 5 as opposed to 1. 
Since we want to capture all json logs that contain the word "Error", I changed the message in the logs to not contain error so that the alarm is not triggered. 
