### PR TITLE
Adding Backup plan to the Infrastructure ADR

### DIFF
--- a/adr/2023-01-31-infrastructure-architecture.md
+++ b/adr/2023-01-31-infrastructure-architecture.md
@@ -101,4 +101,4 @@ The API will need to have a mechanism that prevents direct access to it using th
 ## Other architectual decisions
 
 ### Nightly DynamoDB backup
-In order to satify [CP-9 (Contigency Planning - information systems backup)](https://github.com/cds-snc/url-shortener-documentation/issues/171), we needed to setup an AWS Backup for our DynamoDB tables. Currently, the backup executes via AWS Backup at 12:00am every day and is stored in AWS Vault. In order to allow persistency and to create/run the backup, we wrote a backup plan in [terraform code](https://github.com/cds-snc/url-shortener/tree/main/terragrunt/aws/backup_plan) that executes the preceeding actions.
+In order to satify [CP-9 (Contigency Planning - information systems backup)](https://github.com/cds-snc/url-shortener-documentation/issues/171), we needed to setup an AWS Backup for our DynamoDB tables. Currently, the backup executes via AWS Backup at 12:00am every day and is stored in AWS Vault. In order to allow persistency and to create/run the backup, we wrote a [backup plan](https://github.com/cds-snc/url-shortener/tree/main/terragrunt/aws/backup_plan) using terraform that executes the backup actions.

--- a/adr/2023-01-31-infrastructure-architecture.md
+++ b/adr/2023-01-31-infrastructure-architecture.md
@@ -95,3 +95,10 @@ The API will need to have a mechanism that prevents direct access to it using th
 
 - having CloudFront add a secret header value and then ensuring it's present in the API's handler; or
 - by redirecting all raw Function URL requests to the main API URL. 
+
+
+
+## Other architectual decisions
+
+### Nightly DynamoDB backup
+In order to satify [CP-9 (Contigency Planning - information systems backup)](https://github.com/cds-snc/url-shortener-documentation/issues/171), we needed to setup an AWS Backup for our DynamoDB tables. Currently, the backup executes via AWS Backup at 12:00am every day and is stored in AWS Vault. In order to allow persistency and to create/run the backup, we wrote a backup plan in [terraform code](https://github.com/cds-snc/url-shortener/tree/main/terragrunt/aws/backup_plan) that executes the preceeding actions.


### PR DESCRIPTION
# Summary | Résumé

Added to the Infrastructure ADR the backup plan that we wrote in order to meet ATO compliance. 

Let me know if the explanation is insufficient. 