### PR TITLE
Adding nacl configuration to meet compliance

### DIFF
--- a/terragrunt/aws/network/vpc.tf
+++ b/terragrunt/aws/network/vpc.tf
@@ -28,13 +28,13 @@ resource "aws_network_acl_rule" "block_ssh" {
   egress         = false
   protocol       = "tcp"
   rule_action    = "deny"
-  cidr_block     = "0.0.0.0/0" 
+  cidr_block     = "0.0.0.0/0"
   from_port      = 22
   to_port        = 22
 }
 
 resource "aws_network_acl_rule" "block_rdp" {
-  network_acl_id = module.url_shortener_vpc.main_nacl_id 
+  network_acl_id = module.url_shortener_vpc.main_nacl_id
   rule_number    = 51
   egress         = false
   protocol       = "tcp"

--- a/terragrunt/aws/network/vpc.tf
+++ b/terragrunt/aws/network/vpc.tf
@@ -24,7 +24,7 @@ module "url_shortener_vpc" {
 #
 resource "aws_network_acl_rule" "block_ssh" {
   network_acl_id = module.url_shortener_vpc.main_nacl_id
-  rule_number    = 50
+  rule_number    = 52
   egress         = false
   protocol       = "tcp"
   rule_action    = "deny"
@@ -35,7 +35,7 @@ resource "aws_network_acl_rule" "block_ssh" {
 
 resource "aws_network_acl_rule" "block_rdp" {
   network_acl_id = module.url_shortener_vpc.main_nacl_id
-  rule_number    = 51
+  rule_number    = 53
   egress         = false
   protocol       = "tcp"
   rule_action    = "deny"

--- a/terragrunt/aws/network/vpc.tf
+++ b/terragrunt/aws/network/vpc.tf
@@ -20,6 +20,32 @@ module "url_shortener_vpc" {
 }
 
 #
+# VPC Network ACL
+#
+resource "aws_network_acl_rule" "block_ssh" {
+  network_acl_id = module.url_shortener_vpc.main_nacl_id
+  rule_number    = 50
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "deny"
+  cidr_block     = "0.0.0.0/0" 
+  from_port      = 22
+  to_port        = 22
+}
+
+resource "aws_network_acl_rule" "block_rdp" {
+  network_acl_id = module.url_shortener_vpc.main_nacl_id 
+  rule_number    = 51
+  egress         = false
+  protocol       = "tcp"
+  rule_action    = "deny"
+  cidr_block     = "0.0.0.0/0"
+  from_port      = 3389
+  to_port        = 3389
+}
+
+
+#
 # VPC endpoints
 #
 resource "aws_vpc_endpoint" "logs" {


### PR DESCRIPTION
# Summary | Résumé

Closes #251. In order to satisfy one of the ATO requirements (securityhub-nacl-no-unrestricted-ssh-rdp-f68b9b5d), we needed a NACL rule to block all SSH and RDP traffic and not just on CIDR block 10.0.0.0/16 as was defined in the standard VPC terraform module. This change allows us to meet the requirements and become compliant. 

I could not figure out a way to just modify the existing rule numbers since terraform did not allow me since the rules already existed. The solution is to remove them and then re-add them so if there is a way that this can be done in code, I would love to hear about any suggestions. 