### PR TITLE
Update vpc version to 5.1.5

### DIFF
--- a/terragrunt/aws/network/vpc.tf
+++ b/terragrunt/aws/network/vpc.tf
@@ -3,7 +3,7 @@
 #
 
 module "url_shortener_vpc" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v5.0.0//vpc"
+  source            = "github.com/cds-snc/terraform-modules?ref=v5.1.5//vpc"
   name              = var.product_name
   billing_tag_value = var.billing_code
   high_availability = true


### PR DESCRIPTION
# Summary | Résumé

Closes #251. Updating the VPC version of the url shortener to v.5.1.5 since it contains the latest vpc changes in order to meet ATO compliance. 