### PR TITLE
feat: add contact form target email address

### DIFF
--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -16,6 +16,7 @@ env:
   TF_VAR_slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL_PROD }}
   TF_VAR_hashing_peppers: ${{ secrets.PROD_HASHING_PEPPERS }}
   TF_VAR_notify_api_key: ${{ secrets.PROD_NOTIFY_API_KEY }}
+  TF_VAR_notify_contact_email: ${{ secrets.PROD_NOTIFY_CONTACT_EMAIL }}
 
 permissions:
   id-token: write

--- a/.github/workflows/tf_apply_staging.yml
+++ b/.github/workflows/tf_apply_staging.yml
@@ -18,6 +18,7 @@ env:
   TF_VAR_slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL_STAGING }}
   TF_VAR_hashing_peppers: ${{ secrets.STAGING_HASHING_PEPPERS }}
   TF_VAR_notify_api_key: ${{ secrets.STAGING_NOTIFY_API_KEY }}
+  TF_VAR_notify_contact_email: ${{ secrets.STAGING_NOTIFY_CONTACT_EMAIL }}
 
 permissions:
   id-token: write

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -15,6 +15,7 @@ env:
   TF_VAR_slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL_PROD }}
   TF_VAR_hashing_peppers: ${{ secrets.PROD_HASHING_PEPPERS }}
   TF_VAR_notify_api_key: ${{ secrets.PROD_NOTIFY_API_KEY }}
+  TF_VAR_notify_contact_email: ${{ secrets.PROD_NOTIFY_CONTACT_EMAIL }}
 
 permissions:
   id-token: write

--- a/.github/workflows/tf_plan_staging.yml
+++ b/.github/workflows/tf_plan_staging.yml
@@ -17,6 +17,7 @@ env:
   TF_VAR_slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL_STAGING }}
   TF_VAR_hashing_peppers: ${{ secrets.STAGING_HASHING_PEPPERS }}
   TF_VAR_notify_api_key: ${{ secrets.STAGING_NOTIFY_API_KEY }}
+  TF_VAR_notify_contact_email: ${{ secrets.STAGING_NOTIFY_CONTACT_EMAIL }}
 
 permissions:
   id-token: write

--- a/terragrunt/aws/api/iam.tf
+++ b/terragrunt/aws/api/iam.tf
@@ -28,7 +28,8 @@ data "aws_iam_policy_document" "api_policies" {
       aws_ssm_parameter.auth_token_app.arn,
       aws_ssm_parameter.auth_token_notify.arn,
       aws_ssm_parameter.hashing_peppers.arn,
-      aws_ssm_parameter.notify_api_key.arn
+      aws_ssm_parameter.notify_api_key.arn,
+      aws_ssm_parameter.notify_contact_email.arn
     ]
   }
 }

--- a/terragrunt/aws/api/inputs.tf
+++ b/terragrunt/aws/api/inputs.tf
@@ -49,6 +49,13 @@ variable "ecr_tag" {
 variable "notify_api_key" {
   description = "The API key used to send emails via Notify"
   type        = string
+  sensitive   = true
+}
+
+variable "notify_contact_email" {
+  description = "The email address used by Notify to send contact form emails to"
+  type        = string
+  sensitive   = true
 }
 
 variable "shortener_path_length" {

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -16,6 +16,7 @@ module "url_shortener_lambda" {
 
   environment_variables = {
     ALLOWED_DOMAINS            = "canada.ca,gc.ca,cds-snc.ca"
+    NOTIFY_CONTACT_TEMPLATE    = "47a6be8d-c472-426e-81bb-af1bb89aca87"
     NOTIFY_MAGIC_LINK_TEMPLATE = "092f910a-c3cd-4a91-901d-a2d93fe1e603"
     SHORTENER_DOMAIN           = "https://${var.domain}/"
     SHORTENER_PATH_LENGTH      = var.shortener_path_length

--- a/terragrunt/aws/api/ssm.tf
+++ b/terragrunt/aws/api/ssm.tf
@@ -31,11 +31,21 @@ resource "aws_ssm_parameter" "hashing_peppers" {
   }
 }
 
-
 resource "aws_ssm_parameter" "notify_api_key" {
   name  = "notify_api_key"
   type  = "SecureString"
   value = "NOTIFY_API_KEY=${var.notify_api_key}"
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
+resource "aws_ssm_parameter" "notify_contact_email" {
+  name  = "notify_contact_email"
+  type  = "SecureString"
+  value = "NOTIFY_CONTACT_EMAIL=${var.notify_contact_email}"
 
   tags = {
     CostCentre = var.billing_code


### PR DESCRIPTION
# Summary
Update the `api` module to add the `NOTIFY_CONTACT_EMAIL` secret that will be the email address that contact form submissions are sent to.

Also updates the lambda function with the contact form's Notify template ID.

# Related
- #158 