### PR TITLE
feat: forward API logs to Sentinel

### DIFF
--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -17,6 +17,8 @@ env:
   TF_VAR_hashing_peppers: ${{ secrets.PROD_HASHING_PEPPERS }}
   TF_VAR_notify_api_key: ${{ secrets.PROD_NOTIFY_API_KEY }}
   TF_VAR_notify_contact_email: ${{ secrets.PROD_NOTIFY_CONTACT_EMAIL }}
+  TF_VAR_sentinel_customer_id: ${{ secrets.SENTINEL_CUSTOMER_ID }}
+  TF_VAR_sentinel_shared_key: ${{ secrets.SENTINEL_SHARED_KEY }}    
 
 permissions:
   id-token: write

--- a/.github/workflows/tf_apply_staging.yml
+++ b/.github/workflows/tf_apply_staging.yml
@@ -19,6 +19,8 @@ env:
   TF_VAR_hashing_peppers: ${{ secrets.STAGING_HASHING_PEPPERS }}
   TF_VAR_notify_api_key: ${{ secrets.STAGING_NOTIFY_API_KEY }}
   TF_VAR_notify_contact_email: ${{ secrets.STAGING_NOTIFY_CONTACT_EMAIL }}
+  TF_VAR_sentinel_customer_id: ${{ secrets.SENTINEL_CUSTOMER_ID }}
+  TF_VAR_sentinel_shared_key: ${{ secrets.SENTINEL_SHARED_KEY }}    
 
 permissions:
   id-token: write

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -16,6 +16,8 @@ env:
   TF_VAR_hashing_peppers: ${{ secrets.PROD_HASHING_PEPPERS }}
   TF_VAR_notify_api_key: ${{ secrets.PROD_NOTIFY_API_KEY }}
   TF_VAR_notify_contact_email: ${{ secrets.PROD_NOTIFY_CONTACT_EMAIL }}
+  TF_VAR_sentinel_customer_id: ${{ secrets.SENTINEL_CUSTOMER_ID }}
+  TF_VAR_sentinel_shared_key: ${{ secrets.SENTINEL_SHARED_KEY }}    
 
 permissions:
   id-token: write

--- a/.github/workflows/tf_plan_staging.yml
+++ b/.github/workflows/tf_plan_staging.yml
@@ -18,6 +18,8 @@ env:
   TF_VAR_hashing_peppers: ${{ secrets.STAGING_HASHING_PEPPERS }}
   TF_VAR_notify_api_key: ${{ secrets.STAGING_NOTIFY_API_KEY }}
   TF_VAR_notify_contact_email: ${{ secrets.STAGING_NOTIFY_CONTACT_EMAIL }}
+  TF_VAR_sentinel_customer_id: ${{ secrets.SENTINEL_CUSTOMER_ID }}
+  TF_VAR_sentinel_shared_key: ${{ secrets.SENTINEL_SHARED_KEY }}  
 
 permissions:
   id-token: write

--- a/terragrunt/aws/api/inputs.tf
+++ b/terragrunt/aws/api/inputs.tf
@@ -58,6 +58,18 @@ variable "notify_contact_email" {
   sensitive   = true
 }
 
+variable "sentinel_customer_id" {
+  description = "The Sentinel customer ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "sentinel_shared_key" {
+  description = "The Sentinel shared customer key"
+  type        = string
+  sensitive   = true
+}
+
 variable "shortener_path_length" {
   description = "A variable to set the length of the shortened url"
   type        = string

--- a/terragrunt/aws/api/sentinel.tf
+++ b/terragrunt/aws/api/sentinel.tf
@@ -1,0 +1,17 @@
+locals {
+  api_log_group_arn            = "arn:aws:logs:${var.region}:${var.account_id}:log-group:/aws/lambda/${module.url_shortener_lambda.function_name}"
+  sentinel_forwarder_layer_arn = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:54"
+}
+
+module "sentinel_forwarder" {
+  source            = "github.com/cds-snc/terraform-modules?ref=v5.1.5//sentinel_forwarder"
+  function_name     = "sentinel-cloudwatch-forwarder"
+  billing_tag_value = var.billing_code
+
+  layer_arn = local.sentinel_forwarder_layer_arn
+
+  customer_id = var.sentinel_customer_id
+  shared_key  = var.sentinel_shared_key
+
+  cloudwatch_log_arns = [local.api_log_group_arn]
+}


### PR DESCRIPTION
# Summary 
Add the CloudWatch log group forwarder to send the API's logs to Sentinel.

# Related
- #265 