### PR TITLE
fix: add Sentinel forward log group filter

### DIFF
--- a/terragrunt/aws/api/sentinel.tf
+++ b/terragrunt/aws/api/sentinel.tf
@@ -15,3 +15,11 @@ module "sentinel_forwarder" {
 
   cloudwatch_log_arns = [local.api_log_group_arn]
 }
+
+resource "aws_cloudwatch_log_subscription_filter" "api_request" {
+  name            = "API request"
+  log_group_name  = local.api_log_group_arn
+  filter_pattern  = "?INFO ?WARNING ?ERROR"
+  destination_arn = module.sentinel_forwarder.lambda_arn
+  distribution    = "Random"
+}


### PR DESCRIPTION
# Summary
Add a CloudWatch subscription filter to trigger the forwarding of matching log messages to Sentinel.

# Related
- #265 