### PR TITLE
Include lambda-dead-queue in lambda function as is required by AWS config

### DIFF
--- a/terragrunt/aws/api/inputs.tf
+++ b/terragrunt/aws/api/inputs.tf
@@ -75,3 +75,9 @@ variable "shortener_path_length" {
   type        = string
   default     = "8"
 }
+
+variable "slack_webhook_url" {
+  description = "The URL of the Slack webhook."
+  type        = string
+  sensitive   = true
+}

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -1,5 +1,5 @@
 module "url_shortener_lambda" {
-  source                 = "github.com/cds-snc/terraform-modules?ref=v5.0.2//lambda"
+  source                 = "github.com/cds-snc/terraform-modules?ref=v5.1.5//lambda"
   name                   = "${var.product_name}-api"
   billing_tag_value      = var.billing_code
   ecr_arn                = var.ecr_repository_arn
@@ -7,7 +7,7 @@ module "url_shortener_lambda" {
   image_uri              = "${var.ecr_repository_url}:${var.ecr_tag}"
   memory                 = 3008
   timeout                = 300
-
+  dead_letter_queue_arn  = aws_sns_topic.lambda_dead_letter.arn
 
   vpc = {
     security_group_ids = [var.api_security_group_id]

--- a/terragrunt/aws/api/slack.tf
+++ b/terragrunt/aws/api/slack.tf
@@ -1,0 +1,12 @@
+module "cloudwatch_dead_letter_slack" {
+  source = "github.com/cds-snc/terraform-modules?ref=v5.1.5//notify_slack"
+
+  function_name     = "${var.product_name}-cloudwatch-alarms-slack"
+  project_name      = var.product_name
+  slack_webhook_url = var.slack_webhook_url
+  sns_topic_arns = [
+    aws_sns_topic.lambda_dead_letter.arn,
+  ]
+
+  billing_tag_value = var.billing_code
+}

--- a/terragrunt/aws/api/sns.tf
+++ b/terragrunt/aws/api/sns.tf
@@ -1,0 +1,12 @@
+#
+# SNS: topic & subscription
+#
+resource "aws_sns_topic" "lambda_dead_letter" {
+  name = "cloudwatch-alarms-lambda-dead-letter"
+}
+
+resource "aws_sns_topic_subscription" "alert_lambda_dead_letter" {
+  topic_arn = aws_sns_topic.lambda_dead_letter.arn
+  protocol  = "lambda"
+  endpoint  = module.cloudwatch_dead_letter_slack.lambda_arn
+}


### PR DESCRIPTION
# Summary | Résumé

Changes required to meet lambda-dlq-check-conformance-pack-rfm1tg7he of AWS config. I am also subscribing the topic to a slack module so that we get slack alerts of failures or errors associated with the lambda function. More information can be found [here](https://ca-central-1.console.aws.amazon.com/config/home?region=ca-central-1#/rules/details?conformancePackName=Canadian-Centre-for-Cyber-Security-PBMM&configRuleName=lambda-dlq-check-conformance-pack-rfm1tg7he) as to the specific requirements requested.  

