### PR TITLE
feat: add CodeQL and DAST scanning

### DIFF
--- a/.github/workflows/codeql_scan.yml
+++ b/.github/workflows/codeql_scan.yml
@@ -1,0 +1,28 @@
+name: CodeQL scan
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@d186a2a36cc67bfa1b860e6170d37fb9634742c7 # v2.2.11
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@d186a2a36cc67bfa1b860e6170d37fb9634742c7 # v2.2.11

--- a/.github/workflows/dast_scan.yml
+++ b/.github/workflows/dast_scan.yml
@@ -1,0 +1,31 @@
+name: DAST vulnerability scan
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - "Docker build and push to staging" 
+    types:
+      - completed
+
+jobs:
+  dast-vulnerability-scan:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - url: 'https://url-shortener.cdssandbox.xyz'
+    
+    steps:
+      - name: Run Dastardly
+        uses: PortSwigger/dastardly-github-action@main
+        with:
+          target-url: '${{ matrix.url }}'
+
+      - name: Publish report
+        if: always()
+        uses: mikepenz/action-junit-report@959aefb7f095e717eb407fe917238d61ca323ff3 # v3.7.6
+        with:
+          report_paths: '**/dastardly-report.xml'
+          require_tests: true


### PR DESCRIPTION
# Summary
Add GitHub workflows to perform CodeQL static code analysis and dynamic vulnerability scans with DASTardly.

# Related
- #279 
- cds-snc/url-shortener-documentation#451