### PR TITLE
feat: docker vulnerability scanning

### DIFF
--- a/.github/workflows/docker_scan.yml
+++ b/.github/workflows/docker_scan.yml
@@ -1,0 +1,41 @@
+name: Docker vulnerability scan
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *"
+
+env:
+  REGISTRY: 843973686572.dkr.ecr.ca-central-1.amazonaws.com/url-shortener
+
+permissions:
+  id-token: write
+  security-events: write
+
+jobs:
+  docker-vulnerability-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+        with:
+          role-to-assume: arn:aws:iam::843973686572:role/url-shortener-apply
+          role-session-name: ECRPull
+          aws-region: ca-central-1
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@2f9f10ea3fa2eed41ac443fee8bfbd059af2d0a4 # v1.6.0
+
+      - name: Docker vulnerability scan
+        uses: cds-snc/security-tools/.github/actions/docker-scan@cfec0943e40dbb78cee115bbbe89dc17f07b7a0f # v2.1.3
+        with:
+          docker_image: "${{ env.REGISTRY }}/api:latest"
+          dockerfile_path: "api/Dockerfile"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Logout of Amazon ECR
+        run: docker logout ${{ steps.login-ecr.outputs.registry }}


### PR DESCRIPTION
# Summary
Add a nightly Docker vulnerability scan.  Scan results are published to GitHub Security for the repo.

# Related
- cds-snc/url-shortener-documentation#451