### PR TITLE
docs: add security/contact info and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cds-snc/iplatform-core-services

--- a/README.md
+++ b/README.md
@@ -90,3 +90,8 @@ We currently use k6 to run our loadtests. Assuming you are in the devcontainer:
 
 1. Start the dev server locally, ex: `make e2e-dev` in the `./api` folder.
 2. Run `make loadtest` to start the test script in `./api/loadtesting/test.js`
+
+## Security and support
+If you have any questions or concerns about the security of this application, please consult our [Security policy](SECURITY.md).
+
+If you have support related questions for the service, please use the `Contact Us` feature once you have logged in.


### PR DESCRIPTION
# Summary
- Update the README with links to our Security policy and contact feature.
- Add a CODEOWNERS file.

# Related
- cds-snc/url-shortener-documentation#134