### PR TITLE
Added translation of hash to safe char set

### DIFF
--- a/api/tests/utils/test_helpers.py
+++ b/api/tests/utils/test_helpers.py
@@ -7,6 +7,8 @@ import time
 import advocate
 import requests
 import os
+import string
+import random
 
 
 def round_to(n, roundto):
@@ -16,6 +18,18 @@ def round_to(n, roundto):
 def test_calculate_hash_bytes_ok():
     for length, b in [(4, 3), (5, 4), (6, 5), (7, 6), (8, 6), (9, 7), (10, 8)]:
         assert helpers.calculate_hash_bytes(length) == b
+
+
+def test_translate_safe_charset__letters_translated_ok():
+    safe_charset = "AAEEEFHHJJKLQQQQQRSSWWWXYZaaedefhhhjklqqqqqrsswwwxyz2224456789AZ"
+    tr = "".join(random.choice(string.ascii_letters + "+/") for i in range(100))
+    assert all(c in safe_charset for c in helpers.translate_safe_charset(tr))
+
+
+def test_translate_safe_charset__digits_translated_ok():
+    safe_charset = "AAEEEFHHJJKLQQQQQRSSWWWXYZaaedefhhhjklqqqqqrsswwwxyz2224456789AZ"
+    tr = "".join(random.choice(string.digits) for i in range(100))
+    assert all(c in safe_charset for c in helpers.translate_safe_charset(tr))
 
 
 def test_generate_short_url__length_ok():


### PR DESCRIPTION
This addresses https://github.com/cds-snc/url-shortener/issues/284

Per [discussion](https://gcdigital.slack.com/archives/C04J7RT0FQD/p1682011669452889), it is desirable to improve readability and reduce the likelihood of accidental obscenity in a shortened URL. It is also desirable to follow the guidance set forth by covid alert because it has been tested and approved in both French and English. This implementation: - follows covid alert guidance to use the character set in `AEFHJKLQRSUWXYZ` and `2456789`
- includes the use of lower case characters to reduce the probability of a collision
- excludes `uU` to reduce the likelihood of accidental obscenity per Crockford's Base 32 encoding

@patheard , @sylviamclaughlin Can you review?