### PR TITLE
feat: audit suspicious events and add alarm

### DIFF
--- a/api/middleware/cloudfront.py
+++ b/api/middleware/cloudfront.py
@@ -6,6 +6,7 @@ directly accessible through the Lambda function URL.
 from os import environ
 from fastapi import Request
 from fastapi.responses import JSONResponse
+from logger import log
 
 CLOUDFRONT_HEADER = environ.get("CLOUDFRONT_HEADER", None)
 
@@ -17,6 +18,7 @@ async def check_header(request: Request, call_next):
     "Check if the CloudFront header is present"
     header = request.headers.get("X-CloudFront-Header", None)
     if CLOUDFRONT_HEADER != "localhost" and CLOUDFRONT_HEADER != header:
+        log.warning("SUSPICIOUS: attempted bypass of CloudFront to access API")
         return JSONResponse(
             {"status": "ERROR", "message": "Direct access to the API is not allowed"},
             status_code=403,

--- a/api/utils/auth_token.py
+++ b/api/utils/auth_token.py
@@ -1,10 +1,13 @@
 import os
 from typing import Annotated
+
 from fastapi import Depends
 from fastapi.exceptions import HTTPException
 from fastapi.security import OAuth2PasswordBearer
 from starlette.requests import Request
 from starlette.status import HTTP_401_UNAUTHORIZED
+
+from logger import log
 
 AUTH_TOKEN_APP = os.environ.get("AUTH_TOKEN_APP", None)
 AUTH_TOKEN_NOTIFY = os.environ.get("AUTH_TOKEN_NOTIFY", None)
@@ -31,6 +34,7 @@ def validate_auth_token(
     """
     is_valid = isinstance(token, str) and token.strip() and token in VALID_AUTH_TOKENS
     if not is_valid:
+        log.warning("SUSPICIOUS: failed to validate auth token")
         authorization = request.headers.get("Authorization")
         error_attributes = (
             ', error="invalid_token", error_description="The api key is invalid"'

--- a/api/utils/magic_link.py
+++ b/api/utils/magic_link.py
@@ -39,4 +39,5 @@ def validate_magic_link(guid, email):
         delete(guid)
         return {"success": "success_email_valid"}
     else:
+        log.warning("SUSPICIOUS: attempted login with invalid magic link")
         return {"error": "error_email_not_valid"}

--- a/api/utils/session.py
+++ b/api/utils/session.py
@@ -4,6 +4,8 @@ import uuid
 from fastapi import HTTPException, status, Request
 from models.Session import create, read, delete
 
+from logger import log
+
 COOKIE_NAME = "_sessionID"
 
 
@@ -59,6 +61,9 @@ def validate_user_email(request: Request):
         user_email = session_data["session_data"].get("S")
 
     if not user_email:
+        log.warning(
+            "SUSPICIOUS: failed to get user email from session for an authenticated route"
+        )
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
 
     return user_email

--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -39,7 +39,6 @@ resource "aws_cloudwatch_log_metric_filter" "url_shortener_api_warning" {
   }
 }
 
-
 resource "aws_cloudwatch_metric_alarm" "url_shoretener_api_warning" {
   alarm_name          = "URL Shortener API Warnings"
   alarm_description   = "Warnings logged by the URL Shortener API lambda function"
@@ -51,6 +50,35 @@ resource "aws_cloudwatch_metric_alarm" "url_shoretener_api_warning" {
   evaluation_periods = "1"
   statistic          = "Sum"
   threshold          = var.api_warning_threshold
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.cloudwatch_warning.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_warning.arn]
+}
+
+resource "aws_cloudwatch_log_metric_filter" "url_shortener_api_suspicious" {
+  name           = local.suspicious_logged_api
+  pattern        = "?SUSPICIOUS"
+  log_group_name = local.api_cloudwatch_log_group
+
+  metric_transformation {
+    name      = local.suspicious_logged_api
+    namespace = local.error_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "url_shoretener_api_suspicious" {
+  alarm_name          = "URL Shortener API Suspicious"
+  alarm_description   = "Suspicious activity by users of the URL Shortener API lambda function over 5 minutes"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+
+  metric_name        = aws_cloudwatch_log_metric_filter.url_shortener_api_suspicious.metric_transformation[0].name
+  namespace          = aws_cloudwatch_log_metric_filter.url_shortener_api_suspicious.metric_transformation[0].namespace
+  period             = "300"
+  evaluation_periods = "1"
+  statistic          = "Sum"
+  threshold          = var.api_suspicious_threshold
   treat_missing_data = "notBreaching"
 
   alarm_actions = [aws_sns_topic.cloudwatch_warning.arn]

--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -58,7 +58,7 @@ resource "aws_cloudwatch_metric_alarm" "url_shoretener_api_warning" {
 
 resource "aws_cloudwatch_log_metric_filter" "url_shortener_api_suspicious" {
   name           = local.suspicious_logged_api
-  pattern        = "?SUSPICIOUS"
+  pattern        = "SUSPICIOUS"
   log_group_name = local.api_cloudwatch_log_group
 
   metric_transformation {

--- a/terragrunt/aws/alarms/input.tf
+++ b/terragrunt/aws/alarms/input.tf
@@ -15,6 +15,11 @@ variable "api_error_threshold" {
   type        = string
 }
 
+variable "api_suspicious_threshold" {
+  description = "CloudWatch alarm threshold for the URL Shortener API lambda function SUSPICIOUS logs"
+  type        = string
+}
+
 variable "api_warning_threshold" {
   description = "CloudWatch alarm threshold for the URL Shortener API lambda function WARNING logs"
   type        = string

--- a/terragrunt/aws/alarms/local.tf
+++ b/terragrunt/aws/alarms/local.tf
@@ -2,5 +2,6 @@ locals {
   api_cloudwatch_log_group = "/aws/lambda/${var.function_name}"
   error_logged_api         = "ErrorLoggedAPI"
   error_namespace          = "UrlShortener"
+  suspicious_logged_api    = "Suspicious"
   warning_logged_api       = "WarningLoggedAPI"
 }

--- a/terragrunt/aws/alarms/queries.tf
+++ b/terragrunt/aws/alarms/queries.tf
@@ -13,7 +13,7 @@ resource "aws_cloudwatch_query_definition" "api_errors" {
   QUERY
 }
 
-resource "aws_cloudwatch_query_definition" "api_warnings" {
+resource "aws_cloudwatch_query_definition" "api_suspicious" {
   name = "Suspicious activity API"
 
   log_group_names = [

--- a/terragrunt/aws/alarms/queries.tf
+++ b/terragrunt/aws/alarms/queries.tf
@@ -14,6 +14,21 @@ resource "aws_cloudwatch_query_definition" "api_errors" {
 }
 
 resource "aws_cloudwatch_query_definition" "api_warnings" {
+  name = "Suspicious activity API"
+
+  log_group_names = [
+    local.api_cloudwatch_log_group
+  ]
+
+  query_string = <<-QUERY
+    fields @timestamp, @message, @logStream
+    | filter @message like /SUSPICIOUS/
+    | sort @timestamp desc
+    | limit 20
+  QUERY
+}
+
+resource "aws_cloudwatch_query_definition" "api_warnings" {
   name = "Warnings API"
 
   log_group_names = [

--- a/terragrunt/env/production/alarms/terragrunt.hcl
+++ b/terragrunt/env/production/alarms/terragrunt.hcl
@@ -19,7 +19,8 @@ dependency "api" {
 inputs = {
   function_name  = dependency.api.outputs.function_name
   api_error_threshold                = "1"
-  api_warning_threshold              = "5"
+  api_suspicious_threshold           = "5"
+  api_warning_threshold              = "10"
 }
 
 include {

--- a/terragrunt/env/staging/alarms/terragrunt.hcl
+++ b/terragrunt/env/staging/alarms/terragrunt.hcl
@@ -19,7 +19,8 @@ dependency "api" {
 inputs = {
   function_name                     = dependency.api.outputs.function_name
   api_error_threshold                = "1"
-  api_warning_threshold              = "5"
+  api_suspicious_threshold           = "5"
+  api_warning_threshold              = "10"
 }
 
 include {


### PR DESCRIPTION
# Summary
- Add logging for events that are suspicious if more than a certain threshold occur.
- Add a CloudWatch alarm that triggers if more than 5 suspicious events are logged in a 5 minute period.
- Add a CloudWatch log insight query to view suspicious events.

# Related
- cds-snc/url-shortener-documentation#69