### PR TITLE
fix: change suspicious log wording

### DIFF
--- a/api/utils/auth_token.py
+++ b/api/utils/auth_token.py
@@ -34,7 +34,7 @@ def validate_auth_token(
     """
     is_valid = isinstance(token, str) and token.strip() and token in VALID_AUTH_TOKENS
     if not is_valid:
-        log.warning("SUSPICIOUS: failed to validate auth token")
+        log.warning("SUSPICIOUS: unable to validate auth token for an authenticated route")
         authorization = request.headers.get("Authorization")
         error_attributes = (
             ', error="invalid_token", error_description="The api key is invalid"'

--- a/api/utils/auth_token.py
+++ b/api/utils/auth_token.py
@@ -34,7 +34,9 @@ def validate_auth_token(
     """
     is_valid = isinstance(token, str) and token.strip() and token in VALID_AUTH_TOKENS
     if not is_valid:
-        log.warning("SUSPICIOUS: unable to validate auth token for an authenticated route")
+        log.warning(
+            "SUSPICIOUS: unable to validate auth token for an authenticated route"
+        )
         authorization = request.headers.get("Authorization")
         error_attributes = (
             ', error="invalid_token", error_description="The api key is invalid"'

--- a/api/utils/session.py
+++ b/api/utils/session.py
@@ -62,7 +62,7 @@ def validate_user_email(request: Request):
 
     if not user_email:
         log.warning(
-            "SUSPICIOUS: failed to get user email from session for an authenticated route"
+            "SUSPICIOUS: unable to get user email from session for an authenticated route"
         )
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
 


### PR DESCRIPTION
# Summary
Update the suspicious log wording to avoid accidentally triggering the error alarm which has a metric on the word `failed`.

# Related
- #293 