### PR TITLE
feat: enrol in AWS Shield advanced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,8 +115,6 @@ celerybeat.pid
 .env
 .venv
 venv/
-#env/
-ENV/
 env.bak/
 venv.bak/
 

--- a/terragrunt/aws/alarms/input.tf
+++ b/terragrunt/aws/alarms/input.tf
@@ -1,8 +1,17 @@
+variable "cloudfront_api_arn" {
+  description = "The ARN of the API's CloudFront distribution."
+  type        = string
+}
+
 variable "function_name" {
   description = "The name of the API function."
   type        = string
 }
 
+variable "hosted_zone_id" {
+  description = "The ID of the hosted zone."
+  type        = string
+}
 
 variable "slack_webhook_url" {
   description = "The URL of the Slack webhook."

--- a/terragrunt/aws/alarms/shield_advanced.tf
+++ b/terragrunt/aws/alarms/shield_advanced.tf
@@ -3,7 +3,8 @@ resource "aws_shield_protection" "cloudfront_api" {
   resource_arn = var.cloudfront_api_arn
 
   tags = {
-    (var.billing_tag_key) = var.billing_tag_value
+    CostCentre = var.billing_code
+    Terraform  = true
   }
 }
 
@@ -12,6 +13,7 @@ resource "aws_shield_protection" "route53_hosted_zone" {
   resource_arn = "arn:aws:route53:::hostedzone/${var.hosted_zone_id}"
 
   tags = {
-    (var.billing_tag_key) = var.billing_tag_value
+    CostCentre = var.billing_code
+    Terraform  = true
   }
 }

--- a/terragrunt/aws/alarms/shield_advanced.tf
+++ b/terragrunt/aws/alarms/shield_advanced.tf
@@ -1,0 +1,17 @@
+resource "aws_shield_protection" "cloudfront_api" {
+  name         = "CloudFrontAPI"
+  resource_arn = var.cloudfront_api_arn
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+}
+
+resource "aws_shield_protection" "route53_hosted_zone" {
+  name         = "Route53HostedZone"
+  resource_arn = "arn:aws:route53:::hostedzone/${var.hosted_zone_id}"
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+}

--- a/terragrunt/aws/cloudfront/outputs.tf
+++ b/terragrunt/aws/cloudfront/outputs.tf
@@ -1,0 +1,4 @@
+output "cloudfront_api_arn" {
+  description = "ARN of the API's CloudFront distribution."
+  value       = aws_cloudfront_distribution.url_shortener_api.arn
+}

--- a/terragrunt/env/production/alarms/terragrunt.hcl
+++ b/terragrunt/env/production/alarms/terragrunt.hcl
@@ -3,7 +3,17 @@ terraform {
 }
 
 dependencies {
-  paths = ["../api"]
+  paths = ["../hosted_zone", "../api", "../cloudfront"]
+}
+
+dependency "hosted_zone" {
+  config_path = "../hosted_zone"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs = {
+    hosted_zone_id = "Z00123456I4SMQMHD8PKB"
+  }
 }
 
 dependency "api" {
@@ -12,15 +22,27 @@ dependency "api" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    function_name        = "/aws/lambda/url-shortener-api"
+    function_name = "/aws/lambda/url-shortener-api"
+  }
+}
+
+dependency "cloudfront" {
+  config_path = "../cloudfront"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs = {
+    cloudfront_api_arn = "arn:aws:cloudfront::12345678012:distribution/A2Z6W4OZAEKEKP"
   }
 }
 
 inputs = {
-  function_name  = dependency.api.outputs.function_name
-  api_error_threshold                = "1"
-  api_suspicious_threshold           = "5"
-  api_warning_threshold              = "10"
+  api_error_threshold      = "1"
+  api_suspicious_threshold = "5"
+  api_warning_threshold    = "10"
+  cloudfront_api_arn       = dependency.cloudfront.outputs.cloudfront_api_arn
+  function_name            = dependency.api.outputs.function_name
+  hosted_zone_id           = dependency.hosted_zone.outputs.hosted_zone_id
 }
 
 include {

--- a/terragrunt/env/production/alarms/terragrunt.hcl
+++ b/terragrunt/env/production/alarms/terragrunt.hcl
@@ -32,7 +32,7 @@ dependency "cloudfront" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    cloudfront_api_arn = "arn:aws:cloudfront::12345678012:distribution/A2Z6W4OZAEKEKP"
+    cloudfront_api_arn = "arn:aws:cloudfront::123456789012:distribution/A2Z6W4OZAEKEKP"
   }
 }
 

--- a/terragrunt/env/staging/alarms/terragrunt.hcl
+++ b/terragrunt/env/staging/alarms/terragrunt.hcl
@@ -32,7 +32,7 @@ dependency "cloudfront" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    cloudfront_api_arn = "arn:aws:cloudfront::12345678012:distribution/A2Z6W4OZAEKEKP"
+    cloudfront_api_arn = "arn:aws:cloudfront::123456789012:distribution/A2Z6W4OZAEKEKP"
   }
 }
 

--- a/terragrunt/env/staging/alarms/terragrunt.hcl
+++ b/terragrunt/env/staging/alarms/terragrunt.hcl
@@ -3,7 +3,17 @@ terraform {
 }
 
 dependencies {
-  paths = ["../api"]
+  paths = ["../hosted_zone", "../api", "../cloudfront"]
+}
+
+dependency "hosted_zone" {
+  config_path = "../hosted_zone"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs = {
+    hosted_zone_id = "Z00123456I4SMQMHD8PKB"
+  }
 }
 
 dependency "api" {
@@ -16,11 +26,23 @@ dependency "api" {
   }
 }
 
+dependency "cloudfront" {
+  config_path = "../cloudfront"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs = {
+    cloudfront_api_arn = "arn:aws:cloudfront::12345678012:distribution/A2Z6W4OZAEKEKP"
+  }
+}
+
 inputs = {
-  function_name                     = dependency.api.outputs.function_name
-  api_error_threshold                = "1"
-  api_suspicious_threshold           = "5"
-  api_warning_threshold              = "10"
+  api_error_threshold      = "1"
+  api_suspicious_threshold = "5"
+  api_warning_threshold    = "10"
+  cloudfront_api_arn       = dependency.cloudfront.outputs.cloudfront_api_arn
+  function_name            = dependency.api.outputs.function_name
+  hosted_zone_id           = dependency.hosted_zone.outputs.hosted_zone_id
 }
 
 include {


### PR DESCRIPTION
# Summary
Enrol the API's CloudFront distribution and Route53 hosted zone in AWS Shield Advanced.

# Related
- #276 