### PR TITLE
Exclude rules from conformance pack that are not applicable

### DIFF
--- a/terragrunt/aws/conformance_pack/cds_conformance_pack.tf
+++ b/terragrunt/aws/conformance_pack/cds_conformance_pack.tf
@@ -1,5 +1,6 @@
 module "conformance_pack" {
-  source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.6//cds_conformance_pack"
+  source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.8//cds_conformance_pack"
   internet_gateway_authorized_vpc_only_param_authorized_vpc_ids = var.vpc_id
+  excluded_rules                                                = ["LambdaDlqCheck", "LambdaFunctionPublicAccessProhibited", "S3BucketLoggingEnabled"]
   billing_tag_value                                             = var.billing_code
 }


### PR DESCRIPTION
# Summary | Résumé

PR to exclude rules that are not applicable to the URL shortener. More rules will be added later. The current rules excluded are:
1. LambdaDlqCheck - Config rule name [lambda-dlq-check](https://ca-central-1.console.aws.amazon.com/config/home?region=ca-central-1#/rules/details?configRuleName=lambda-dlq-check-conformance-pack-75rwmzoyh). This is not applicable to us since we are not invoking Lambdas asynchronously.
2. LambdaFunctionPublicAccessProhibited - Config rule name [lambda-function-public-access-prohibited](https://ca-central-1.console.aws.amazon.com/config/home?region=ca-central-1#/rules/details?configRuleName=lambda-function-public-access-prohibited-conformance-pack-75rwmzoyh). We need our lambda function to be publicly available for the url shortener to work. 
3. S3BucketLoggingEnabled - Config rule name [s3-bucket-logging-enabled](https://ca-central-1.console.aws.amazon.com/config/home?region=ca-central-1#/rules/details?configRuleName=securityhub-s3-bucket-logging-enabled-186fac6a). We use the s3 buckets only for terraform state so this should not be necessary. BUT let me know if I am wrong, especially now that we store some the conformance pack in an S3 bucket. 