### PR TITLE
fix: slack notify SNS topic ARNs

### DIFF
--- a/terragrunt/aws/alarms/slack.tf
+++ b/terragrunt/aws/alarms/slack.tf
@@ -6,6 +6,7 @@ module "cloudwatch_alarms_slack" {
   slack_webhook_url = var.slack_webhook_url
   sns_topic_arns = [
     aws_sns_topic.cloudwatch_warning.arn,
+    aws_sns_topic.cloudwatch_warning_us_east.arn,
   ]
 
   billing_tag_value = var.billing_code


### PR DESCRIPTION
# Summary
Update the Slack notify lambda function to allow the US East 1 SNS Topic to invoke it.  This topic is used by the AWS Shield Advanced DDoS alarms.

# Related
- Closes #276 