### PR TITLE
fix: exclude more config rules

### DIFF
--- a/terragrunt/aws/conformance_pack/cds_conformance_pack.tf
+++ b/terragrunt/aws/conformance_pack/cds_conformance_pack.tf
@@ -1,6 +1,18 @@
 module "conformance_pack" {
-  source                                                        = "github.com/cds-snc/terraform-modules?ref=v5.1.8//cds_conformance_pack"
-  internet_gateway_authorized_vpc_only_param_authorized_vpc_ids = var.vpc_id
-  excluded_rules                                                = ["LambdaDlqCheck", "LambdaFunctionPublicAccessProhibited", "S3BucketLoggingEnabled"]
-  billing_tag_value                                             = var.billing_code
+  source = "github.com/cds-snc/terraform-modules?ref=v5.1.8//cds_conformance_pack"
+
+  cloudwatch_alarm_action_check_param_insufficient_data_action_required = false
+  internet_gateway_authorized_vpc_only_param_authorized_vpc_ids         = var.vpc_id
+
+  excluded_rules = [
+    "CloudTrailCloudWatchLogsEnabled",      # CloudTrail logs are delivered to S3
+    "CloudTrailEncryptionEnabled",          # Default CloudTrail encryption is acceptable
+    "LambdaDlqCheck",                       # Lambda API only uses syncronous invocations
+    "LambdaFunctionPublicAccessProhibited", # Public access is required for the Lambda API
+    "S3BucketLoggingEnabled",               # S3 access logging is monitored through CloudTrail events by CCCS
+    "S3BucketReplicationEnabled",           # S3 bucket replication is not required
+    "S3BucketVersioningEnabled",            # S3 bucket versioning is not required
+  ]
+
+  billing_tag_value = var.billing_code
 }


### PR DESCRIPTION
# Summary
Update the list of excluded rules and added a comment explanation for each.

Also no longer require a CloudWatch alarm `insufficient action` to be considered compliant.

# Related
- cds-snc/url-shortener-documentation#454