### PR TITLE
feat: add production Docker workflows

### DIFF
--- a/.github/workflows/build_and_push_production.yml
+++ b/.github/workflows/build_and_push_production.yml
@@ -1,0 +1,48 @@
+name: Docker build and push to production
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  GITHUB_SHA: ${{ github.sha }}
+  REGISTRY: 806721586252.dkr.ecr.ca-central-1.amazonaws.com/url-shortener
+  AWS_REGION: ca-central-1  
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+        with:
+          role-to-assume: arn:aws:iam::806721586252:role/url-shortener-apply
+          role-session-name: ECRPush
+          aws-region: ca-central-1
+
+      - name: Build image
+        working-directory: ./api
+        run: |
+          docker build \
+            --build-arg GIT_SHA=$GITHUB_SHA \
+            -t $REGISTRY/api:$GITHUB_SHA
+
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@2f9f10ea3fa2eed41ac443fee8bfbd059af2d0a4 # v1.6.0
+
+      - name: Push image to ECR
+        run: |
+          docker push $REGISTRY/api:$GITHUB_SHA
+
+      - name: Logout of Amazon ECR
+        if: always()
+        run: docker logout ${{ steps.login-ecr.outputs.registry }}

--- a/.github/workflows/build_and_push_staging.yml
+++ b/.github/workflows/build_and_push_staging.yml
@@ -15,10 +15,6 @@ env:
 permissions:
   id-token: write
   contents: write
-  pull-requests: write
-  actions: write
-  checks: write
-  statuses: write
   security-events: write
 
 jobs:
@@ -42,6 +38,7 @@ jobs:
           --build-arg GIT_SHA=$GITHUB_SHA \
           -t $REGISTRY/api:$GITHUB_SHA \
           -t $REGISTRY/api:latest .
+
       - name: Login to ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@2f9f10ea3fa2eed41ac443fee8bfbd059af2d0a4 # v1.6.0
@@ -50,6 +47,7 @@ jobs:
         run: |
           docker push $REGISTRY/api:$GITHUB_SHA
           docker push $REGISTRY/api:latest
+
       - name: Docker generate SBOM
         uses: cds-snc/security-tools/.github/actions/generate-sbom@cfec0943e40dbb78cee115bbbe89dc17f07b7a0f # v2.1.3
         with:

--- a/.github/workflows/deploy_api_production.yml
+++ b/.github/workflows/deploy_api_production.yml
@@ -8,6 +8,7 @@ on:
       - .github/manifests/lambda_api_version
 
 env:
+  AWS_REGION: ca-central-1
   FUNCTION_NAME: url-shortener-api
   REGISTRY: 806721586252.dkr.ecr.ca-central-1.amazonaws.com/url-shortener
 
@@ -27,7 +28,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::806721586252:role/url-shortener-apply
           role-session-name: DeployAPI
-          aws-region: ca-central-1
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Deploy lambda
         run: |
@@ -35,6 +36,9 @@ jobs:
           aws lambda update-function-code \
             --function-name ${{ env.FUNCTION_NAME }} \
             --image-uri $REGISTRY/api:$VERSION  > /dev/null 2>&1
+
+      - name: CloudFront cache invalidate
+        run: aws cloudfront create-invalidation --distribution-id ${{ secrets.PROD_CLOUDFRONT_DIST_ID }} --paths "/*"
 
       - name: API healthcheck
         uses: jtalk/url-health-check-action@61a0e49fff5cde3773b0bbe069d4ebbd04d24f07 # tag=v2

--- a/.github/workflows/deploy_api_production.yml
+++ b/.github/workflows/deploy_api_production.yml
@@ -1,0 +1,44 @@
+name: Deploy API to production
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/manifests/lambda_api_version
+
+env:
+  FUNCTION_NAME: url-shortener-api
+  REGISTRY: 806721586252.dkr.ecr.ca-central-1.amazonaws.com/url-shortener
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy-lambda:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Configure AWS credentials using OIDC
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+        with:
+          role-to-assume: arn:aws:iam::806721586252:role/url-shortener-apply
+          role-session-name: DeployAPI
+          aws-region: ca-central-1
+
+      - name: Deploy lambda
+        run: |
+          VERSION="$(cat .github/manifests/lambda_api_version)"
+          aws lambda update-function-code \
+            --function-name ${{ env.FUNCTION_NAME }} \
+            --image-uri $REGISTRY/api:$VERSION  > /dev/null 2>&1
+
+      - name: API healthcheck
+        uses: jtalk/url-health-check-action@61a0e49fff5cde3773b0bbe069d4ebbd04d24f07 # tag=v2
+        with:
+          url: https://o.alpha.canada.ca/healthcheck
+          max-attempts: 3
+          retry-delay: 5s


### PR DESCRIPTION
# Summary
Add workflows to build/push the production Docker image and deploy new versions of the API.  The API prod deployment will be triggered by changes to a `.github/manifests/lambda_api_version` file, which will contain the Docker image tag to update the Lambda API function with.

Also narrows the workflow permissions on the Staging Docker build/push workflow.

# Related
- #298 