### PR TITLE
fix: unique name for WAF's login URI path regex

### DIFF
--- a/terragrunt/aws/cloudfront/waf.tf
+++ b/terragrunt/aws/cloudfront/waf.tf
@@ -354,7 +354,7 @@ resource "aws_wafv2_regex_pattern_set" "valid_uri_paths" {
 
 resource "aws_wafv2_regex_pattern_set" "login_uri_paths" {
   provider    = aws.us-east-1
-  name        = "valid-api-paths"
+  name        = "login-uri-paths"
   description = "Regex to match the login paths of the API"
   scope       = "CLOUDFRONT"
 


### PR DESCRIPTION
# Summary 
Update the WAF login URI path regex pattern set to have a unique name.

# Related
- #303 
- #298 