### PR TITLE
feat: validate email on login

### DIFF
--- a/.github/workflows/build_and_push_production.yml
+++ b/.github/workflows/build_and_push_production.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           docker build \
             --build-arg GIT_SHA=$GITHUB_SHA \
-            -t $REGISTRY/api:$GITHUB_SHA
+            -t $REGISTRY/api:$GITHUB_SHA .
 
       - name: Login to ECR
         id: login-ecr

--- a/api/routers/shortener.py
+++ b/api/routers/shortener.py
@@ -1,6 +1,7 @@
 import os
 import re
 
+from email.utils import parseaddr
 from typing import Annotated, Optional
 from fastapi import (
     APIRouter,
@@ -108,12 +109,15 @@ def login_post(locale: Locale, request: Request, email: Optional[str] = Form("")
     """
     Attempts to generate and send a magic login link to the given email address.
     """
-    domain = email.split("@").pop()
-    result = {}
+    # Check if the email address looks valid
+    email_parsed = parseaddr(email)
+    domain = email.split("@").pop() if "@" in email_parsed[1] else None
+
     if domain in os.getenv("ALLOWED_DOMAINS").split(","):
         result = create_magic_link(email)
     else:
-        result["error"] = "error_invalid_email_address"
+        result = {"error": "error_invalid_email_address"}
+
     data = {
         "error": result.get("error", None),
         "success": result.get("success", None),

--- a/api/tests/routers/test_shortener.py
+++ b/api/tests/routers/test_shortener.py
@@ -77,6 +77,15 @@ def test_POST_login_returns_200_with_error_message_if_not_in_domain_list(
 
 
 @patch("routers.shortener.create_magic_link")
+def test_POST_login_returns_200_with_error_message_if_invalid_email(
+    mock_create_magic_link, client, login_path
+):
+    response = client.post(login_path, data={"email": "certainly-not-an-email"})
+    assert response.status_code == status.HTTP_200_OK
+    mock_create_magic_link.assert_not_called()
+
+
+@patch("routers.shortener.create_magic_link")
 @patch("routers.shortener.get_language")
 def test_POST_login_returns_200_with_error_message_if_magic_link_fails(
     mock_get_language, mock_create_magic_link, client, login_path, locale


### PR DESCRIPTION
# Summary
Add basic email validation before attempting to send the
magic link through Notify.

Also fix a bug with the prod Docker build/push workflow.

# Related
- #298 