### PR TITLE
Adding additional rules for exclusion

### DIFF
--- a/terragrunt/aws/conformance_pack/cds_conformance_pack.tf
+++ b/terragrunt/aws/conformance_pack/cds_conformance_pack.tf
@@ -12,6 +12,7 @@ module "conformance_pack" {
     "S3BucketLoggingEnabled",               # S3 access logging is monitored through CloudTrail events by CCCS
     "S3BucketReplicationEnabled",           # S3 bucket replication is not required
     "S3BucketVersioningEnabled",            # S3 bucket versioning is not required
+    "SnsEncryptedKms",			    # Encryption at rest not required for Alarm topic
   ]
 
   billing_tag_value = var.billing_code

--- a/terragrunt/aws/conformance_pack/cds_conformance_pack.tf
+++ b/terragrunt/aws/conformance_pack/cds_conformance_pack.tf
@@ -9,6 +9,7 @@ module "conformance_pack" {
     "CloudTrailEncryptionEnabled",          # Default CloudTrail encryption is acceptable
     "LambdaDlqCheck",                       # Lambda API only uses syncronous invocations
     "LambdaFunctionPublicAccessProhibited", # Public access is required for the Lambda API
+    "LambdaInsideVpc",			    # Lambda functions outside VPC are org level functions
     "S3BucketLoggingEnabled",               # S3 access logging is monitored through CloudTrail events by CCCS
     "S3BucketReplicationEnabled",           # S3 bucket replication is not required
     "S3BucketVersioningEnabled",            # S3 bucket versioning is not required


### PR DESCRIPTION
# Summary | Résumé

Adding additional rules to exclude from the rule set:
1.  SnsEncryptedKms ([sns-encrypted-kms](https://docs.aws.amazon.com/config/latest/developerguide/sns-encrypted-kms.html)) and can be excluded since encryption at rest not required for Alarm topic
2. LambdaInsideVpc - ([lambda-inside-vpc](https://docs.aws.amazon.com/config/latest/developerguide/lambda-inside-vpc.html)) . The lambdas that don't comply with this rule are all org level functions. 
![Screen Shot 2023-04-25 at 7 55 19 AM](https://user-images.githubusercontent.com/85905333/234368085-3f337b7d-886f-4edd-a88c-42232c49663b.png)
