### PR TITLE
feat: add honeypot to prevent login form spam

### DIFF
--- a/api/routers/shortener.py
+++ b/api/routers/shortener.py
@@ -105,7 +105,12 @@ def login(locale: Locale, request: Request):
 
 @router.post("/{locale}/connexion", response_class=HTMLResponse)
 @router.post("/{locale}/login", response_class=HTMLResponse)
-def login_post(locale: Locale, request: Request, email: Optional[str] = Form("")):
+def login_post(
+    locale: Locale,
+    request: Request,
+    email: Optional[str] = Form(""),
+    cache: Optional[str] = Form(""),
+):
     """
     Attempts to generate and send a magic login link to the given email address.
     """
@@ -113,7 +118,8 @@ def login_post(locale: Locale, request: Request, email: Optional[str] = Form("")
     email_parsed = parseaddr(email)
     domain = email.split("@").pop() if "@" in email_parsed[1] else None
 
-    if domain in os.getenv("ALLOWED_DOMAINS").split(","):
+    # `cache` is a hidden field used as a honeypot to prevent bots from spamming the login form.
+    if not cache and domain in os.getenv("ALLOWED_DOMAINS").split(","):
         result = create_magic_link(email)
     else:
         result = {"error": "error_invalid_email_address"}

--- a/api/templates/login.html
+++ b/api/templates/login.html
@@ -10,6 +10,8 @@
 <form action="/{{ i18n.lang }}/{{ i18n.login_path }}" method="post" class="mb-500">
     <gcds-input label="{{ i18n.email }}" type="email" input-id="email" value="{{ data.email }}"
         error-message="{{ i18n[data.error] }}" required /></gcds-input>
+    
+    <label for="cache" aria-hidden="true" class="d-none" >Cache <input type="radio" name="cache" id="cache" value="1" class="d-none"></label>
     <gcds-button type="submit">{{ i18n.login }}</gcds-button>
 </form>
 {% endif %}

--- a/api/tests/routers/test_shortener.py
+++ b/api/tests/routers/test_shortener.py
@@ -86,6 +86,15 @@ def test_POST_login_returns_200_with_error_message_if_invalid_email(
 
 
 @patch("routers.shortener.create_magic_link")
+def test_POST_login_returns_200_with_error_message_if_honeypot(
+    mock_create_magic_link, client, login_path
+):
+    response = client.post(login_path, data={"email": "foo@canada.ca", "cache": "1"})
+    assert response.status_code == status.HTTP_200_OK
+    mock_create_magic_link.assert_not_called()
+
+
+@patch("routers.shortener.create_magic_link")
 @patch("routers.shortener.get_language")
 def test_POST_login_returns_200_with_error_message_if_magic_link_fails(
     mock_get_language, mock_create_magic_link, client, login_path, locale


### PR DESCRIPTION
# Summary 
Add a honeypot field to the login form to cut down on bot spam from fuzzing attacks.

It is visually hidden and hidden from assistive technology.