### PR TITLE
feat: post to Slack if a GitHub workflow fails

### DIFF
--- a/.github/workflows/workflow_failure.yml
+++ b/.github/workflows/workflow_failure.yml
@@ -1,0 +1,17 @@
+name: Workflow failure
+
+on:
+  workflow_run:
+    workflows: ["*"]
+    types:
+      - completed
+
+jobs:
+  on-failure:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow.name != 'Workflow failure'
+    steps:
+      - name: Notify Slack
+        run: |
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: GitHub workflow failed: <${{ github.event.workflow_run.html_url }}|${{ github.event.workflow.name }}>"}}]}'
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.SLACK_WEBHOOK_PRODUCT_CHANNEL }}


### PR DESCRIPTION
# Summary
Add a workflow that will post an alert to Slack if one of the product GitHub workflows fails.