### PR TITLE
fix: DynamoDB backup plan

### DIFF
--- a/terragrunt/aws/backup_plan/locals.tf
+++ b/terragrunt/aws/backup_plan/locals.tf
@@ -4,5 +4,5 @@ locals {
   plan_schedule_default         = "cron(0 12 * * ? *)" # every day at 12:00
   plan_schedule_default_testing = "cron(0 12 * * ? *)" # once every 10 minutes for testing
   cold_storage_after_default    = 7
-  delete_after_default          = 14
+  delete_after_default          = 97 # Must be 90 days or more after cold storage
 }


### PR DESCRIPTION
# Summary
The delete must be 90 days after the cold storage date.
