### PR TITLE
chore: limit workflow failure notifications

### DIFF
--- a/.github/workflows/workflow_failure.yml
+++ b/.github/workflows/workflow_failure.yml
@@ -2,14 +2,19 @@ name: Workflow failure
 
 on:
   workflow_run:
-    workflows: ["*"]
+    workflows:
+      - "Deploy API to production"
+      - "Docker build and push to production"
+      - "Docker build and push to staging"
+      - "Terraform apply production"
+      - "Terraform apply staging"
     types:
       - completed
 
 jobs:
   on-failure:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow.name != 'Workflow failure'
+    if: github.event.workflow_run.conclusion == 'failure'
     steps:
       - name: Notify Slack
         run: |


### PR DESCRIPTION
# Summary
Only notify product Slack channel when listed GitHub workflows fail.