### PR TITLE
feat: check short URL still valid

### DIFF
--- a/api/utils/helpers.py
+++ b/api/utils/helpers.py
@@ -142,6 +142,11 @@ def resolve_short_url(short_url):
     if result is None:
         log.warning(f"Could not resolve url: {short_url}")
         return False
+    elif not is_domain_allowed(result["original_url"]["S"]):
+        log.warning(
+            f"SUSPICIOUS: found shortened URL '{short_url}' that is not allowed for '{result['original_url']['S']}'"
+        )
+        return False
     return result
 
 


### PR DESCRIPTION
# Summary 
Update the short URL resolve function to check that a found short URL still meets the `ALLOWED_DOMAINS` restrictions.

Remove 2 unit tests that were not working as expected and being tested as part of the ShortUrls model unit tests.

# Related
- #333 