### PR TITLE
feat: WAF ACL login challenge

### DIFF
--- a/terragrunt/aws/alarms/cloudwatch_api.tf
+++ b/terragrunt/aws/alarms/cloudwatch_api.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_log_metric_filter" "url_shortener_api_error" {
   name           = local.error_logged_api
-  pattern        = "?ERROR ?Error ?failed"
+  pattern        = "?ERROR ?Error"
   log_group_name = local.api_cloudwatch_log_group
 
   metric_transformation {

--- a/terragrunt/aws/cloudfront/waf.tf
+++ b/terragrunt/aws/cloudfront/waf.tf
@@ -293,6 +293,48 @@ resource "aws_wafv2_web_acl" "api_waf" {
     }
   }
 
+  rule {
+    name     = "LoginChallenge"
+    priority = 60
+
+    action {
+      dynamic "challenge" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {
+        }
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {
+        }
+      }
+    }
+
+    statement {
+      regex_pattern_set_reference_statement {
+        arn = aws_wafv2_regex_pattern_set.login_uri_paths.arn
+        field_to_match {
+          uri_path {}
+        }
+        text_transformation {
+          priority = 1
+          type     = "COMPRESS_WHITE_SPACE"
+        }
+        text_transformation {
+          priority = 2
+          type     = "LOWERCASE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "LoginChallenge"
+      sampled_requests_enabled   = true
+    }
+  }
+
   visibility_config {
     cloudwatch_metrics_enabled = true
     metric_name                = "api"


### PR DESCRIPTION
# Summary
Add a WAF ACL `challenge` rule for the login paths.  This will cause the [WAF to issue a transparent challenge](https://docs.aws.amazon.com/waf/latest/developerguide/waf-captcha-and-challenge.html) to all requests to the login URLs to stop bot access.

Update the ERROR metric to remove the word `failed` to avoid triggering on the added user info logging.

# Related
- #327 