### PR TITLE
fix: green/blue versions

### DIFF
--- a/.github/workflows/build_and_push_staging.yml
+++ b/.github/workflows/build_and_push_staging.yml
@@ -67,10 +67,10 @@ jobs:
             aws lambda wait function-updated --function-name ${{ env.FUNCTION_PREFIX }}-api
             echo "VERSION=$(aws lambda publish-version --function-name ${{ env.FUNCTION_PREFIX }}-api | jq -r '.Version')" >> $GITHUB_ENV
 
-      - name: Shift lambda traffic over 10 minutes
+      - name: Shift lambda traffic over 4 minutes
         uses: cds-snc/aws-lambda-traffic-shifting-action@0.4
         env:
-            ALIAS: ${{ env.FUNCTION_PREFIX }}-api
+            ALIAS: latest
             FUNCTION_NAME: ${{ env.FUNCTION_PREFIX }}-api
             GREEN_VERSION: ${{ env.VERSION }}
             ROLLOUT_STEPS: 4

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -27,7 +27,22 @@ module "url_shortener_lambda" {
   ]
 }
 
+resource "aws_lambda_alias" "url_shortener_lambda_alias" {
+  name             = "latest"
+  description      = "The latest version of the lambda function"
+  function_name    = module.url_shortener_lambda.function_name
+  function_version = "1"
+
+  lifecycle {
+    ignore_changes = [
+      function_version,
+      routing_config
+    ]
+  }
+}
+
 resource "aws_lambda_function_url" "url_shortener_url" {
   function_name      = module.url_shortener_lambda.function_name
+  qualifier          = aws_lambda_alias.url_shortener_lambda_alias.name
   authorization_type = "NONE"
 }


### PR DESCRIPTION
Part of #274. This PR adds the alias `latest` to the terraform code while ignoring any changes to the function version and routing configuration which will be handled by the green/blue deploy action. It also re-routes the function url to the `latest` alias.