### PR TITLE
fix: email suffix checks

### DIFF
--- a/api/routers/shortener.py
+++ b/api/routers/shortener.py
@@ -35,7 +35,11 @@ from utils.i18n import (
     get_locale_from_path,
     get_locale_order,
 )
-from utils.magic_link import create_magic_link, validate_magic_link
+from utils.magic_link import (
+    create_magic_link,
+    is_allowed_email_domain,
+    validate_magic_link,
+)
 from utils.session import (
     delete_cookie,
     set_cookie,
@@ -129,6 +133,7 @@ def login_post(
     Attempts to generate and send a magic login link to the given email address.
     """
     # Check if the email address looks valid
+    allowed_domains = os.getenv("ALLOWED_DOMAINS").split(",")
     email_parsed = parseaddr(email)
     domain = email.split("@").pop() if "@" in email_parsed[1] else None
     is_valid_token = validate_token(login_token, LOGIN_TOKEN_SALT)
@@ -137,7 +142,7 @@ def login_post(
     if not is_valid_token or cache:
         result = {"error": "error_login_failed"}
     # Email is not a safelisted domain
-    elif domain not in os.getenv("ALLOWED_DOMAINS").split(","):
+    elif not is_allowed_email_domain(allowed_domains, domain):
         result = {"error": "error_invalid_email_address"}
     # All is good, send the magic link
     else:

--- a/api/tests/utils/test_magic_link.py
+++ b/api/tests/utils/test_magic_link.py
@@ -53,6 +53,21 @@ def test_create_magic_link_returns_error_if_notify_throws_an_error(
     assert result == {"error": "error_send_magic_link_email"}
 
 
+def test_is_allowed_email_domain_returns_false_if_domain_is_not_allowed():
+    result = magic_link.is_allowed_email_domain(["canada.ca", "gc.ca"], "aircanada.ca")
+    assert result is False
+
+
+def test_is_allowed_email_domain_returns_true_if_domain_is_allowed():
+    result = magic_link.is_allowed_email_domain(["canada.ca", "gc.ca"], "foo.gc.ca")
+    assert result is True
+
+
+def test_is_allowed_email_domain_returns_false_if_domain_is_None():
+    result = magic_link.is_allowed_email_domain(["canada.ca", "gc.ca"], None)
+    assert result is False
+
+
 @patch("utils.magic_link.get")
 def test_validate_magic_link_returns_error_if_magic_link_is_not_valid(mock_get):
     mock_get.return_value = None

--- a/api/utils/magic_link.py
+++ b/api/utils/magic_link.py
@@ -36,6 +36,18 @@ def create_magic_link(email):
     return result
 
 
+def is_allowed_email_domain(domain_list, domain):
+    """
+    Returns True if the given domain is a subdomain of any of the domains in the list.
+    """
+    if domain is None:
+        return False
+    for d in domain_list:
+        if domain.endswith("." + d) or domain == d:
+            return True
+    return False
+
+
 def validate_magic_link(guid, email):
     link_email = get(guid)
     if email == link_email:


### PR DESCRIPTION
Closes #346. Fixes an issues where `gc.ca` is a valid email domain but `tbs-sct.gc.ca` is not. The edge case to check for is somebody trying to register with `foogc.ca`.