### PR TITLE
feat: alarm for high number of magic link emails

### DIFF
--- a/terragrunt/aws/alarms/cloudwatch_api.tf
+++ b/terragrunt/aws/alarms/cloudwatch_api.tf
@@ -84,3 +84,32 @@ resource "aws_cloudwatch_metric_alarm" "url_shoretener_api_suspicious" {
   alarm_actions = [aws_sns_topic.cloudwatch_warning.arn]
   ok_actions    = [aws_sns_topic.cloudwatch_warning.arn]
 }
+
+resource "aws_cloudwatch_log_metric_filter" "url_shortener_api_magic_link_sent" {
+  name           = local.magic_link_sent
+  pattern        = "success_magic_link_sent_email"
+  log_group_name = local.api_cloudwatch_log_group
+
+  metric_transformation {
+    name      = local.magic_link_sent
+    namespace = local.error_namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "url_shoretener_api_high_magic_link_sent" {
+  alarm_name          = "URL Shortener API high magic link sent"
+  alarm_description   = "A high number of magic link emails sent over 5 minutes"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+
+  metric_name        = aws_cloudwatch_log_metric_filter.url_shortener_api_magic_link_sent.metric_transformation[0].name
+  namespace          = aws_cloudwatch_log_metric_filter.url_shortener_api_magic_link_sent.metric_transformation[0].namespace
+  period             = "300"
+  evaluation_periods = "1"
+  statistic          = "Sum"
+  threshold          = var.api_high_magic_link_sent_threshold
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.cloudwatch_warning.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_warning.arn]
+}

--- a/terragrunt/aws/alarms/input.tf
+++ b/terragrunt/aws/alarms/input.tf
@@ -24,6 +24,11 @@ variable "api_error_threshold" {
   type        = string
 }
 
+variable "api_high_magic_link_sent_threshold" {
+  description = "CloudWatch alarm threshold for the URL Shortener API lambda function magic link emails sent in a 5 minute period"
+  type        = string
+}
+
 variable "api_suspicious_threshold" {
   description = "CloudWatch alarm threshold for the URL Shortener API lambda function SUSPICIOUS logs"
   type        = string

--- a/terragrunt/aws/alarms/local.tf
+++ b/terragrunt/aws/alarms/local.tf
@@ -2,6 +2,7 @@ locals {
   api_cloudwatch_log_group = "/aws/lambda/${var.function_name}"
   error_logged_api         = "ErrorLoggedAPI"
   error_namespace          = "UrlShortener"
+  magic_link_sent          = "MagicLinkSent"
   suspicious_logged_api    = "Suspicious"
   warning_logged_api       = "WarningLoggedAPI"
 }

--- a/terragrunt/env/production/alarms/terragrunt.hcl
+++ b/terragrunt/env/production/alarms/terragrunt.hcl
@@ -37,12 +37,13 @@ dependency "cloudfront" {
 }
 
 inputs = {
-  api_error_threshold      = "1"
-  api_suspicious_threshold = "5"
-  api_warning_threshold    = "10"
-  cloudfront_api_arn       = dependency.cloudfront.outputs.cloudfront_api_arn
-  function_name            = dependency.api.outputs.function_name
-  hosted_zone_id           = dependency.hosted_zone.outputs.hosted_zone_id
+  api_error_threshold                = "1"
+  api_high_magic_link_sent_threshold = "10"
+  api_suspicious_threshold           = "5"
+  api_warning_threshold              = "10"
+  cloudfront_api_arn                 = dependency.cloudfront.outputs.cloudfront_api_arn
+  function_name                      = dependency.api.outputs.function_name
+  hosted_zone_id                     = dependency.hosted_zone.outputs.hosted_zone_id
 }
 
 include {

--- a/terragrunt/env/staging/alarms/terragrunt.hcl
+++ b/terragrunt/env/staging/alarms/terragrunt.hcl
@@ -37,12 +37,13 @@ dependency "cloudfront" {
 }
 
 inputs = {
-  api_error_threshold      = "1"
-  api_suspicious_threshold = "5"
-  api_warning_threshold    = "10"
-  cloudfront_api_arn       = dependency.cloudfront.outputs.cloudfront_api_arn
-  function_name            = dependency.api.outputs.function_name
-  hosted_zone_id           = dependency.hosted_zone.outputs.hosted_zone_id
+  api_error_threshold                = "1"
+  api_high_magic_link_sent_threshold = "10"
+  api_suspicious_threshold           = "5"
+  api_warning_threshold              = "10"
+  cloudfront_api_arn                 = dependency.cloudfront.outputs.cloudfront_api_arn
+  function_name                      = dependency.api.outputs.function_name
+  hosted_zone_id                     = dependency.hosted_zone.outputs.hosted_zone_id
 }
 
 include {


### PR DESCRIPTION
# Summary
Add a CloudWatch alarm that triggers when a high number of magic link emails have been sent in a 5 minute period.

This is being done to watch for abuse of the Notify API key.