### PR TITLE
fix: print stack trace when Exceptions are caught

### DIFF
--- a/api/routers/ops.py
+++ b/api/routers/ops.py
@@ -2,6 +2,7 @@
 API routes for for operational and status requests
 """
 from os import environ
+import traceback
 from fastapi import APIRouter
 import boto3
 from logger import log
@@ -40,7 +41,7 @@ def is_db_up():
         table_name = environ.get("TABLE_NAME", "url_shortener")
         client.describe_table(TableName=table_name)
     # Catch all errors, log the error and return False
-    except Exception as err:
-        log.error(f"Error in healthcheck: {err}")
+    except Exception:
+        log.error(f"Error in healthcheck: {traceback.format_exc()}")
         return False
     return True

--- a/api/utils/contact.py
+++ b/api/utils/contact.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 from logger import log
 from utils.helpers import notification_client
 
@@ -25,7 +26,7 @@ def send_contact_email(
                 "contact_details": contact_details[:10000],
             },
         )
-    except Exception as error:
-        log.error("Failed to send contact email: %s", error)
+    except Exception:
+        log.error("Failed to send contact email: %s", traceback.format_exc())
         return {"error": "error_contact_send_failed"}
     return {"success": "success_contact_sent"}

--- a/api/utils/helpers.py
+++ b/api/utils/helpers.py
@@ -3,6 +3,7 @@ import datetime
 import hashlib
 import math
 import os
+import traceback
 
 from urllib.parse import urlparse
 
@@ -161,8 +162,8 @@ def return_short_url(original_url, peppers, created_by):
     except advocate.UnacceptableAddressException:
         log.warning(f"Unacceptable address: {original_url}")
         return {"error": "error_forbidden_resource"}
-    except requests.RequestException as err:
-        log.error(f"Failed to connect to {original_url}: {err}")
+    except requests.RequestException:
+        log.error(f"Failed to connect to {original_url}: {traceback.format_exc()}")
         return {"error": "error_filed_to_connect_url"}
 
     peppers_iter = iter(peppers)
@@ -240,8 +241,10 @@ def validate_and_shorten_url(original_url, created_by):
                 "status": "OK",
             }
 
-    except Exception as err:
-        log.error("Could not shorten URL '%s': %s", original_url, err)
+    except Exception:
+        log.error(
+            "Could not shorten URL '%s': %s", original_url, traceback.format_exc()
+        )
         data = {
             "error": "error_url_shorten_failed",
             "original_url": original_url,

--- a/api/utils/magic_link.py
+++ b/api/utils/magic_link.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 
 from models.MagicLinks import create, delete, get, check_if_exists
 from logger import log
@@ -25,8 +26,8 @@ def create_magic_link(email):
                     },
                 )
                 result = {"success": "success_magic_link_sent_email"}
-            except Exception as error:
-                log.error(error)
+            except Exception:
+                log.error("Failed to send magic link: %s", traceback.format_exc())
                 result = {"error": "error_send_magic_link_email"}
         else:
             result = {"error": "error_create_magic_link"}


### PR DESCRIPTION
# Summary
Update the `log.error` to print stack traces when an Exception is caught.

# Related
- #355 