### PR TITLE
fix: log warning when cannot connect to URL

### DIFF
--- a/api/utils/helpers.py
+++ b/api/utils/helpers.py
@@ -163,7 +163,7 @@ def return_short_url(original_url, peppers, created_by):
         log.warning(f"Unacceptable address: {original_url}")
         return {"error": "error_forbidden_resource"}
     except requests.RequestException:
-        log.error(f"Failed to connect to {original_url}: {traceback.format_exc()}")
+        log.warning(f"Failed to connect to {original_url}: {traceback.format_exc()}")
         return {"error": "error_filed_to_connect_url"}
 
     peppers_iter = iter(peppers)


### PR DESCRIPTION
# Summary
Update the logging to a `warning` when advocate fails to connect to a given URL.  This is being done because users can enter a valid looking URL that does not exist, in which case we don't want to alert the app team.