### PR TITLE
Expiry of Urls after 2 years since last access date

### DIFF
--- a/api/models/ShortUrls.py
+++ b/api/models/ShortUrls.py
@@ -4,6 +4,7 @@ import datetime
 import time
 import os
 
+
 client = boto3.client(
     "dynamodb",
     endpoint_url=(os.environ.get("DYNAMODB_HOST", None)),
@@ -28,9 +29,8 @@ def create_short_url(original_url, short_url, created_by):
 
     returns: shortened url
     """
-    # Expire an url after 2 years in epoch time
-    two_years_time = datetime.datetime.today() + datetime.timedelta(days=(365 * 2))
-    expiry_date = int(time.mktime(two_years_time.timetuple()))
+    # Expire an url after 2 years in epoch time since its creation or last accessed date
+    expiry_date = get_two_year_future_time()
     try:
         response = client.put_item(
             TableName=table,
@@ -41,6 +41,9 @@ def create_short_url(original_url, short_url, created_by):
                 "active": {"BOOL": True},
                 "created_at": {"N": str(int(datetime.datetime.utcnow().timestamp()))},
                 "created_by": {"S": created_by},
+                "last_access_at": {
+                    "N": str(int(datetime.datetime.utcnow().timestamp()))
+                },
                 "ttl": {"N": str(expiry_date)},
             },
             ConditionExpression="attribute_not_exists(key_id)",
@@ -70,6 +73,7 @@ def get_short_url(short_url):
     # AWS does not delete expired items immediately (typically deletes within 48 hours)
     # so we still need to sure we don't return any expired urls
     epoch_time_now = int(time.time())
+    print("epoch_time_now", epoch_time_now)
     response = client.query(
         TableName=table,
         KeyConditionExpression="#key_id = :key_id",
@@ -87,13 +91,29 @@ def get_short_url(short_url):
         and "Items" in response
         and len(response["Items"]) > 0
     ):
-        # Update the URL's click count
+        # Update the URL's click count, last accessed date and new expiry date
+        print("Get two year future time: ", get_two_year_future_time())
         client.update_item(
             TableName=table,
             Key={"key_id": {"S": f"{MODEL_PREFIX}/{short_url}"}},
-            UpdateExpression="SET click_count = click_count + :val",
-            ExpressionAttributeValues={":val": {"N": "1"}},
+            UpdateExpression="SET click_count = click_count + :val, last_access_date = :current_date, #ttl = :expiry_date",
+            ExpressionAttributeValues={
+                ":val": {"N": "1"},
+                ":current_date": {
+                    "N": str(int(datetime.datetime.utcnow().timestamp()))
+                },
+                ":expiry_date": {"N": str(get_two_year_future_time())},
+            },
+            ExpressionAttributeNames={
+                "#ttl": "ttl"
+  }
         )
         return response["Items"][0]
     else:
         return None
+
+    
+def get_two_year_future_time():
+    """Get the current time plus two years in epoch time"""
+    two_years_time = datetime.datetime.today() + datetime.timedelta(days=(365 * 2))
+    return int(time.mktime(two_years_time.timetuple()))

--- a/api/tests/models/test_ShortUrls.py
+++ b/api/tests/models/test_ShortUrls.py
@@ -28,20 +28,26 @@ class TestCreateShortUrl(TestCase):
         assert short_url["click_count"]["N"] == "2"
 
     def test_update_last_access_at(self):
-        ShortUrls.create_short_url("https://www.canada.ca", "test", "actor")
-        short_url = ShortUrls.get_short_url("test")
-        assert short_url["last_access_at"]["N"] == short_url["created_at"]["N"]
-        time.sleep(5)
-        short_url = ShortUrls.get_short_url("test")
-        assert short_url["last_access_at"]["N"] != short_url["created_at"]["N"]
+        """Test that we are setting the last_access_date properly and it is being updated each time the shortned url is retrieved"""
+        ShortUrls.create_short_url("https://www.canada.ca", "xyz", "actor")
+        time.sleep(1)
+        short_url = ShortUrls.get_short_url("xyz")
+        assert short_url["last_access_date"]["N"] == short_url["created_at"]["N"]
+        short_url = ShortUrls.get_short_url("xyz")
+        time.sleep(1)
+        assert short_url["last_access_date"]["N"] != short_url["created_at"]["N"]
+        previous_last_access_date = int(short_url["last_access_date"]["N"])
+        short_url = ShortUrls.get_short_url("xyz")
+        assert short_url["last_access_date"]["N"] != previous_last_access_date
 
-    def test_ttl_time(self):
-        ShortUrls.create_short_url("https://www.canada.ca", "test", "actor")
-        short_url = ShortUrls.get_short_url("test")
-        two_years_time = str(ShortUrls.get_two_year_future_time())
-        assert short_url["ttl"]["N"] == two_years_time 
-        short_url = ShortUrls.get_short_url("test")
-        assert short_url["ttl"]["N"] != two_years_time
+    def test_update_ttl_time(self):
+        """Test that we are setting the ttl properly and it is being updated each time the shortned url is retrieved"""
+        ShortUrls.create_short_url("https://www.canada.ca", "abc", "actor")
+        time.sleep(1)
+        short_url = ShortUrls.get_short_url("abc")
+        previous_ttl = int(short_url["ttl"]["N"])
+        short_url = ShortUrls.get_short_url("abc")
+        assert short_url["ttl"]["N"] != str(previous_ttl)
 
     def test_ttl_is_valid(self):
         short_url = ShortUrls.get_short_url("test")

--- a/api/tests/models/test_ShortUrls.py
+++ b/api/tests/models/test_ShortUrls.py
@@ -27,6 +27,22 @@ class TestCreateShortUrl(TestCase):
         short_url = ShortUrls.get_short_url("test")
         assert short_url["click_count"]["N"] == "2"
 
+    def test_update_last_access_at(self):
+        ShortUrls.create_short_url("https://www.canada.ca", "test", "actor")
+        short_url = ShortUrls.get_short_url("test")
+        assert short_url["last_access_at"]["N"] == short_url["created_at"]["N"]
+        time.sleep(5)
+        short_url = ShortUrls.get_short_url("test")
+        assert short_url["last_access_at"]["N"] != short_url["created_at"]["N"]
+
+    def test_ttl_time(self):
+        ShortUrls.create_short_url("https://www.canada.ca", "test", "actor")
+        short_url = ShortUrls.get_short_url("test")
+        two_years_time = str(ShortUrls.get_two_year_future_time())
+        assert short_url["ttl"]["N"] == two_years_time 
+        short_url = ShortUrls.get_short_url("test")
+        assert short_url["ttl"]["N"] != two_years_time
+
     def test_ttl_is_valid(self):
         short_url = ShortUrls.get_short_url("test")
         epoch_time_now = int(time.time())

--- a/api/utils/helpers.py
+++ b/api/utils/helpers.py
@@ -2,7 +2,6 @@ import base64
 import datetime
 import hashlib
 import math
-import time
 import os
 
 from urllib.parse import urlparse
@@ -294,5 +293,3 @@ def notification_client():
     return NotificationsAPIClient(
         NOTIFY_API_KEY, base_url="https://api.notification.canada.ca"
     )
-
-

--- a/api/utils/helpers.py
+++ b/api/utils/helpers.py
@@ -2,6 +2,7 @@ import base64
 import datetime
 import hashlib
 import math
+import time
 import os
 
 from urllib.parse import urlparse
@@ -293,3 +294,5 @@ def notification_client():
     return NotificationsAPIClient(
         NOTIFY_API_KEY, base_url="https://api.notification.canada.ca"
     )
+
+


### PR DESCRIPTION
# Summary | Résumé

Implemented a last access date that gets updated every time the shortened url is retrieved. Also, set the expiry date or ttl of the dynamobd entry to be 2 years since the last access date. 

Closes #275 