### PR TITLE
fix: update to new GCDS utility CSS path

### DIFF
--- a/api/templates/base.html
+++ b/api/templates/base.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="https://unpkg.com/@cdssnc/gcds-components/dist/gcds/gcds.css">
   <script type="module" src="https://unpkg.com/@cdssnc/gcds-components/dist/gcds/gcds.esm.js"></script>
   <script nomodule src="https://unpkg.com/@cdssnc/gcds-components/dist/gcds/gcds.js"></script>
-  <link rel="stylesheet" href="https://unpkg.com/@cdssnc/gcds-utility/dist/utilities.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/@cdssnc/gcds-utility/dist/gcds-utility.min.css">
 
   <link rel="stylesheet" href="/static/css/app.css">
 


### PR DESCRIPTION
# Summary
Update to the new `gcds-utility.css` file.