### PR TITLE
fix: split the ALLOWED_DOMAINS into two env vars

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -18,7 +18,8 @@ services:
         VARIANT: "3.11"
         NODE_VERSION: "none"
     environment:
-      ALLOWED_DOMAINS: 'canada.ca,gc.ca,cds-snc.ca'
+      ALLOWED_EMAIL_DOMAINS: 'canada.ca,gc.ca,cds-snc.ca'
+      ALLOWED_SHORTENED_DOMAINS: 'canada.ca,gc.ca'
       AUTH_TOKEN_APP: 'auth_token_app'
       AUTH_TOKEN_NOTIFY: 'auth_token_notify'
       AWS_ACCESS_KEY_ID: 'AWS_ACCESS_KEY_ID'

--- a/.github/workflows/cypress_e2e.yml
+++ b/.github/workflows/cypress_e2e.yml
@@ -53,7 +53,8 @@ jobs:
           nohup make e2e-dev &
           make e2e-ci
         env:
-          ALLOWED_DOMAINS: "canada.ca,gc.ca"
+          ALLOWED_EMAIL_DOMAINS: "canada.ca,gc.ca"
+          ALLOWED_SHORTENED_DOMAINS: "canada.ca,gc.ca"
           AUTH_TOKEN_APP: "auth_token_app"
           AUTH_TOKEN_NOTIFY: "auth_token_notify"
           AWS_ACCESS_KEY_ID: "AWS_ACCESS_KEY_ID"

--- a/.github/workflows/loadtesting.yml
+++ b/.github/workflows/loadtesting.yml
@@ -38,7 +38,7 @@ jobs:
           AWS_ACCESS_KEY_ID: 'AWS_ACCESS_KEY_ID'
           AWS_SECRET_ACCESS_KEY: 'AWS_SECRET_ACCESS_KEY'
           AWS_REGION: 'ca-central-1'
-     
+
 
       - name: Install dev dependencies
         working-directory: ./api
@@ -61,7 +61,8 @@ jobs:
           sleep 5
           make loadtest
         env:
-          ALLOWED_DOMAINS: "canada.ca,gc.ca"
+          ALLOWED_EMAIL_DOMAINS: "canada.ca,gc.ca"
+          ALLOWED_SHORTENED_DOMAINS: "canada.ca,gc.ca"
           AUTH_TOKEN_APP: "auth_token_app"
           AUTH_TOKEN_NOTIFY: "auth_token_notify"
           AWS_ACCESS_KEY_ID: "AWS_ACCESS_KEY_ID"
@@ -73,7 +74,7 @@ jobs:
           LOGIN_TOKEN_SALT: "je_suis_un_sel"
           NOTIFY_API_KEY: ""
           NOTIFY_CONTACT_EMAIL: ""
-          NOTIFY_CONTACT_TEMPLATE: ""          
+          NOTIFY_CONTACT_TEMPLATE: ""
           NOTIFY_MAGIC_LINK_TEMPLATE: ""
           PEPPERS: 'ejp8zh0QHl1BKPMvH4d9zFvS1rkbnYz9uqaEae9uwmY=,fwNAF1u7dA3j0YtsOoHtE0wIzCisSyzqTOhI4TkG5dA=,W2ktstHWiB1+UJLku8Mi0f1Su5RhX+p7hx7UxsrNVOE=,QIPgZU1zZ/tdLAigsLPl4j1zQ8Yc2rUMrVrSMTnZwlM=,sUUmk4x4tgVvfAxM9cu/ZCeIL88SJefJYFkZcHERYEY='
           SHORTENER_DOMAIN: "http://127.0.0.1:8000/"

--- a/api/main.py
+++ b/api/main.py
@@ -19,12 +19,16 @@ description = """
 API to shorten a url
 """
 
-ALLOWED_DOMAINS = environ.get("ALLOWED_DOMAINS", "").split(",")
+ALLOWED_EMAIL_DOMAINS = environ.get("ALLOWED_EMAIL_DOMAINS", "").split(",")
+ALLOWED_SHORTENED_DOMAINS = environ.get("ALLOWED_SHORTENED_DOMAINS", "").split(",")
 SHORTENER_DOMAIN = environ.get("SHORTENER_DOMAIN", "")
 DOCS_URL = environ.get("DOCS_URL", None)
 
-if len(ALLOWED_DOMAINS) == 0:
-    raise ValueError("ALLOWED_DOMAINS environment variable is empty")
+if len(ALLOWED_EMAIL_DOMAINS) == 0:
+    raise ValueError("ALLOWED_EMAIL_DOMAINS environment variable is empty")
+
+if len(ALLOWED_SHORTENED_DOMAINS) == 0:
+    raise ValueError("ALLOWED_SHORTENED_DOMAINS environment variable is empty")
 
 if len(SHORTENER_DOMAIN.strip()) == 0:
     raise ValueError("SHORTENER_DOMAIN environment variable is empty")

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -2,7 +2,8 @@
 testpaths = tests
 asyncio_mode = auto
 env =  
-    ALLOWED_DOMAINS=canada.ca,gc.ca
+    ALLOWED_EMAIL_DOMAINS=canada.ca,gc.ca
+    ALLOWED_SHORTENED_DOMAINS=canada.ca,gc.ca
     AUTH_TOKEN_APP=auth_token_app
     AUTH_TOKEN_NOTIFY=auth_token_notify
     CLOUDFRONT_HEADER=localhost

--- a/api/routers/shortener.py
+++ b/api/routers/shortener.py
@@ -133,7 +133,7 @@ def login_post(
     Attempts to generate and send a magic login link to the given email address.
     """
     # Check if the email address looks valid
-    allowed_domains = os.getenv("ALLOWED_DOMAINS").split(",")
+    allowed_domains = os.getenv("ALLOWED_EMAIL_DOMAINS").split(",")
     email_parsed = parseaddr(email)
     domain = email.split("@").pop() if "@" in email_parsed[1] else None
     is_valid_token = validate_token(login_token, LOGIN_TOKEN_SALT)

--- a/api/tests/utils/test_helpers.py
+++ b/api/tests/utils/test_helpers.py
@@ -164,7 +164,7 @@ def test_is_valid_url_returns_false_if_throws_an_exception(mock_validators):
 
 
 @patch("utils.helpers.ShortUrls")
-@patch.dict(os.environ, {"ALLOWED_DOMAINS": "foo_bar.com"}, clear=True)
+@patch.dict(os.environ, {"ALLOWED_SHORTENED_DOMAINS": "foo_bar.com"}, clear=True)
 def test_resolve_short_url_returns_original_url(mock_short_urls_model):
     short_url = "XjbS35ah"
     mock_short_urls_model.get_short_url.return_value = {
@@ -185,7 +185,7 @@ def test_resolve_short_url_returns_false_if_it_does_not_exist(mock_short_urls_mo
 
 
 @patch("utils.helpers.ShortUrls")
-@patch.dict(os.environ, {"ALLOWED_DOMAINS": "bam_baz.com"}, clear=True)
+@patch.dict(os.environ, {"ALLOWED_SHORTENED_DOMAINS": "bam_baz.com"}, clear=True)
 def test_resolve_short_url_returns_false_if_it_is_not_allowed(mock_short_urls_model):
     short_url = "XjbS35ah"
     mock_short_urls_model.get_short_url.return_value = {

--- a/api/utils/helpers.py
+++ b/api/utils/helpers.py
@@ -110,7 +110,7 @@ def is_domain_allowed(original_url):
     try:
         # Obtain the domain from the url
         domain = ".".join(urlparse(original_url).hostname.split(".")[-2:])
-        return domain in os.getenv("ALLOWED_DOMAINS").split(",")
+        return domain in os.getenv("ALLOWED_SHORTENED_DOMAINS").split(",")
     except Exception:
         return {"error": "error retrieving domain"}
 

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -15,7 +15,8 @@ module "url_shortener_lambda" {
   }
 
   environment_variables = {
-    ALLOWED_DOMAINS            = "canada.ca,gc.ca,cds-snc.ca"
+    ALLOWED_EMAIL_DOMAINS      = "canada.ca,gc.ca,cds-snc.ca"
+    ALLOWED_SHORTENED_DOMAINS  = "canada.ca,gc.ca"
     NOTIFY_CONTACT_TEMPLATE    = "47a6be8d-c472-426e-81bb-af1bb89aca87"
     NOTIFY_MAGIC_LINK_TEMPLATE = "092f910a-c3cd-4a91-901d-a2d93fe1e603"
     SHORTENER_DOMAIN           = "https://${var.domain}/"


### PR DESCRIPTION
# Summary
Update the allowed email domains and allowed shortened domains to be controlled by two distinct environment variables.

This will allow us to have more fine grained control over which email domains can login and which URLs can be shortened.

# Related
- #367 
- cds-snc/security-risk-register#151