### PR TITLE
fix: use `/version` endpoint for healthcheck

### DIFF
--- a/.github/workflows/deploy_api_production.yml
+++ b/.github/workflows/deploy_api_production.yml
@@ -57,6 +57,6 @@ jobs:
       - name: API healthcheck
         uses: jtalk/url-health-check-action@61a0e49fff5cde3773b0bbe069d4ebbd04d24f07 # tag=v2
         with:
-          url: https://o.alpha.canada.ca/healthcheck
+          url: https://o.alpha.canada.ca/version
           max-attempts: 3
           retry-delay: 5s

--- a/adr/2023-02-06-api-architecture.md
+++ b/adr/2023-02-06-api-architecture.md
@@ -78,8 +78,6 @@ To aid in automated ops workflows the API shall expose the following 'GET' endpo
 
 * /version - Which shall return the GIT_SHA of the currently deployed code
 
-* /healthcheck - Indicating the health of the service - the details of which are intentionally vague
-
 ## / - POST
 
 ## /v1/shorten - POST

--- a/api/routers/ops.py
+++ b/api/routers/ops.py
@@ -2,10 +2,7 @@
 API routes for for operational and status requests
 """
 from os import environ
-import traceback
 from fastapi import APIRouter
-import boto3
-from logger import log
 
 
 router = APIRouter()
@@ -16,32 +13,3 @@ router = APIRouter()
 def version():
     "Commit SHA of the deployed version"
     return {"version": environ.get("GIT_SHA", "unknown")}
-
-
-# Return the healthcheck of the service
-@router.get("/healthcheck")
-def healthcheck():
-    "Simple healthcheck to check if the service is running. Connects to the dynamoDB and sees if it can describe the main table"
-    if is_db_up():
-        return {"status": "OK", "message": "Able to connect to the database"}
-    else:
-        return {"status": "ERROR", "message": "Not able to connect to the database"}
-
-
-# Get the status of the dynamoDB database. We create the datatabse with the specified table name and then describe the table, essentially checking its status.
-def is_db_up():
-    try:
-        # connect and get the url_shortener table. After that, describe the table to make sure that it exists and there are no errors
-        # associated with it. If there are errors, return False otherwise return True
-        client = boto3.client(
-            "dynamodb",
-            endpoint_url=(environ.get("DYNAMODB_HOST", None)),
-            region_name="ca-central-1",
-        )
-        table_name = environ.get("TABLE_NAME", "url_shortener")
-        client.describe_table(TableName=table_name)
-    # Catch all errors, log the error and return False
-    except Exception:
-        log.error(f"Error in healthcheck: {traceback.format_exc()}")
-        return False
-    return True

--- a/terragrunt/aws/cloudfront/cloudfront.tf
+++ b/terragrunt/aws/cloudfront/cloudfront.tf
@@ -36,9 +36,9 @@ resource "aws_cloudfront_distribution" "url_shortener_api" {
     origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac" # AllViewerExceptHostHeader https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html
   }
 
-  # Prevent caching of healthcheck calls
+  # Prevent caching of version calls
   ordered_cache_behavior {
-    path_pattern    = "/healthcheck"
+    path_pattern    = "/version"
     allowed_methods = ["GET", "HEAD"]
     cached_methods  = ["GET", "HEAD"]
 

--- a/terragrunt/aws/cloudfront/waf.tf
+++ b/terragrunt/aws/cloudfront/waf.tf
@@ -350,7 +350,7 @@ resource "aws_wafv2_regex_pattern_set" "valid_uri_paths" {
 
   # ops
   regular_expression {
-    regex_string = "^/(version|healthcheck|openapi.json|.well-known/security.txt)$"
+    regex_string = "^/(version|openapi.json|.well-known/security.txt)$"
   }
 
   # api call to shorten url

--- a/terragrunt/aws/hosted_zone/route53.tf
+++ b/terragrunt/aws/hosted_zone/route53.tf
@@ -11,7 +11,7 @@ resource "aws_route53_health_check" "sre_bot_healthcheck" {
   fqdn              = aws_route53_zone.url_shortener.name
   port              = 443
   type              = "HTTPS"
-  resource_path     = "/healthcheck"
+  resource_path     = "/version"
   failure_threshold = "3"
   request_interval  = "30"
 


### PR DESCRIPTION
# Summary
Remove the `/healthcheck` endpoint that queries DynamoDB and replace it with the `/version` endpoint.

This is being done to address the security risk identified of unauthenticated requests to our data source being used in a DoS attack.

# Related
- cds-snc/security-risk-register#150