### PR TITLE
fix: set cookie `secure=True` attribute

### DIFF
--- a/api/utils/session.py
+++ b/api/utils/session.py
@@ -25,6 +25,7 @@ def set_cookie(response, session_data):
             key=COOKIE_NAME,
             value=session_id,
             httponly=True,
+            secure=True,
             max_age=60 * 60 * 2,  # 2 hours
             expires=60 * 60 * 2,  # 2 hours
             samesite="lax",


### PR DESCRIPTION
# Summary
Update the cookie so that it can no longer sent in plaintext with unecrypted requests.

# Related
- cds-snc/security-risk-register#147