### PR TITLE
fix: set max URL length that can shorten

### DIFF
--- a/api/i18n/en.json
+++ b/api/i18n/en.json
@@ -20,6 +20,7 @@
     "error_url_shorten_invalid": "Unable to shorten URL.",
     "error_url_shorten_invalid_host": "The URL is not recognized as an Official Government of Canada Domain.",
     "error_url_shorten_invalid_scheme": "Unable to shorten URL. Invalid Scheme; only https is permitted.",
+    "error_url_shorten_url_too_long": "The URL is too long.",
     "error_url_shorten_url_not_valid": "The URL is not valid.",
     "gc_link_shortener": "GC URL Shortener",
     "home": "Home",

--- a/api/i18n/fr.json
+++ b/api/i18n/fr.json
@@ -20,6 +20,7 @@
     "error_url_shorten_invalid": "Impossible de raccourcir l'URL.",
     "error_url_shorten_invalid_host": "L'URL n'est pas reconnu comme un domaine officiel du gouvernement du Canada.",
     "error_url_shorten_invalid_scheme": "Impossible de raccourcir l'URL. Schéma non valide ; seul https est autorisé.",
+    "error_url_shorten_url_too_long": "L'URL est trop long.",
     "error_url_shorten_url_not_valid": "L'URL n'est pas valide.",
     "gc_link_shortener": "Raccourcisseur d'URLs GC",
     "how_can_we_help" : "Quel est votre besoin ?",

--- a/api/tests/utils/test_helpers.py
+++ b/api/tests/utils/test_helpers.py
@@ -202,6 +202,16 @@ def test_resolve_short_url_returns_fixture_if_cypress_env_var_is_set():
     assert result == {"original_url": {"S": "https://digital.canada.ca/"}}
 
 
+def test_validate_and_shorten_url_returns_error_if_url_too_long():
+    original_url = f"https://example.com/{'x' * 2048}"
+    result = helpers.validate_and_shorten_url(original_url, "actor")
+    assert result == {
+        "error": "error_url_shorten_url_too_long",
+        "original_url": original_url,
+        "status": "ERROR",
+    }
+
+
 def test_validate_and_shorten_url_returns_error_if_invalid_url():
     original_url = "https://example.com"
     helpers.is_valid_url = MagicMock(return_value=False)

--- a/api/utils/helpers.py
+++ b/api/utils/helpers.py
@@ -17,6 +17,7 @@ from logger import log
 from notifications_python_client.notifications import NotificationsAPIClient
 
 
+MAX_URL_LENGTH = 2048
 NOTIFY_API_KEY = os.environ.get("NOTIFY_API_KEY", None)
 
 
@@ -208,6 +209,13 @@ def validate_and_shorten_url(original_url, created_by):
         elif not is_valid_scheme(original_url):
             data = {
                 "error": "error_url_shorten_invalid_scheme",
+                "original_url": original_url,
+                "status": "ERROR",
+            }
+        # Else if URL is too long
+        elif len(original_url) >= MAX_URL_LENGTH:
+            data = {
+                "error": "error_url_shorten_url_too_long",
                 "original_url": original_url,
                 "status": "ERROR",
             }


### PR DESCRIPTION
# Summary
Update the URL validation logic to prevent URLs longer than 2048 characters from being shortened.

For simplicity, I am continuing to return a `400` HTTP status code from the API if this error condition is triggered.

# Related
- cds-snc/security-risk-register#153