### PR TITLE
fix: return the record `ttl` field

### DIFF
--- a/api/models/MagicLinks.py
+++ b/api/models/MagicLinks.py
@@ -49,7 +49,8 @@ def get(guid):
     response = client.get_item(
         TableName=table,
         Key={"key_id": {"S": f"{MODEL_PREFIX}/{guid}"}},
-        ProjectionExpression="email",
+        ExpressionAttributeNames={"#ttl": "ttl"},
+        ProjectionExpression="email,#ttl",
     )
     if response["ResponseMetadata"]["HTTPStatusCode"] == 200 and "Item" in response:
         if (

--- a/api/tests/models/test_MagicLinks.py
+++ b/api/tests/models/test_MagicLinks.py
@@ -61,7 +61,7 @@ def test_get_returns_none_if_get_item_succeeds_but_ttl_has_passed(
         },
     }
     assert MagicLinks.get("guid") is None
-    mock_delete.assert_called_once()
+    mock_delete.assert_called_with("guid")
 
 
 @patch("models.MagicLinks.client.query")


### PR DESCRIPTION
# Summary
Update the magic link `get` method to return the record's `ttl` so that it can be compared to the current time.

Prior to this fix, `"ttl" in response["Item"]` was False, which meant that the magic link remained valid up until DynamoDB cleaned up expired items.

# Related
- #380 