### PR TITLE
chore: log info when URL cannot be resolved

### DIFF
--- a/api/utils/helpers.py
+++ b/api/utils/helpers.py
@@ -142,7 +142,7 @@ def resolve_short_url(short_url):
         return {"original_url": {"S": "https://digital.canada.ca/"}}
     result = ShortUrls.get_short_url(short_url)
     if result is None:
-        log.warning(f"Could not resolve url: {short_url}")
+        log.info(f"UNRESOLVABLE: Could not resolve url: {short_url}")
         return False
     elif not is_domain_allowed(result["original_url"]["S"]):
         log.warning(


### PR DESCRIPTION
# Summary
Update the logging for an unresolvable URL to `info` so that we're not alerted during fuzzing attacks.