### PR TITLE
fix: remove the Route53 DNS resolver firewall

### DIFF
--- a/terragrunt/aws/cloudfront/route53.tf
+++ b/terragrunt/aws/cloudfront/route53.tf
@@ -11,23 +11,11 @@ resource "aws_route53_record" "url_shortener_A" {
 }
 
 #
-# Route53 DNS logging and query firewall
+# Route53 DNS logging
 #
 module "resolver_dns" {
-  source           = "github.com/cds-snc/terraform-modules?ref=v5.0.2//resolver_dns"
-  vpc_id           = var.vpc_id
-  firewall_enabled = true
-
-  allowed_domains = [
-    "*.akamaiedge.net.",
-    "*.amazonaws.com.",
-    "*.edgekey.net.",
-    "*.gc.ca.",
-    "*.gg.ca.",
-    "*.canada.ca.",
-    "canada.ca.",
-    "gg.ca.",
-  ]
-
+  source            = "github.com/cds-snc/terraform-modules?ref=v5.0.2//resolver_dns"
+  vpc_id            = var.vpc_id
+  firewall_enabled  = false
   billing_tag_value = var.billing_code
 }


### PR DESCRIPTION
# Summary
Remove the Route53 DNS resolver firewall as this will become a challenge to maintain with how each CNAME in the DNS chain must be allowed for a URL to resolve properly when adding a short URL.

# Related
- cds-snc/platform-core-services#361