### PR TITLE
fix: add closing `fi` to entry.sh

### DIFF
--- a/api/bin/entry.sh
+++ b/api/bin/entry.sh
@@ -68,7 +68,7 @@ else
             echo "Failed to retrieve secrets"
             exit 1
         fi
-
+    fi
     load_non_existing_envs
 
    echo "Starting lambda handler"


### PR DESCRIPTION
# Summary
Fix the missing `fi` from the Docker entry.sh.

# Related
- #397 
- #388 