### PR TITLE
fix: remove temp `.env` file if not populated

### DIFF
--- a/api/bin/entry.sh
+++ b/api/bin/entry.sh
@@ -67,6 +67,7 @@ else
     # Check if secrets were retrieved
     if [ ! -s "$TMP_ENV_FILE" ]; then
         echo "Failed to retrieve secrets"
+        rm "$TMP_ENV_FILE"
         exit 1
     fi
     load_non_existing_envs


### PR DESCRIPTION
# Summary
Update the API's `entry.sh` to delete the temp `.env` file if it was not loaded properly.  This will allow subsequent lambda invocations to attempt to reload the secrets instead of being caught in a broken state.

# Related
- #388 