### PR TITLE
fix: DynamoDB local AWS access key

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   db:
     command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ./data"
-    image: "amazon/dynamodb-local:latest@sha256:2f27c0d54589009b0acb275116398addeed75f4301c51d724ed8bad655bc017d"
+    image: "amazon/dynamodb-local:latest@sha256:c8702bde709520b90930c20ee430d4123cd731da8e544cc4ccae0e2a78ee4fce"
     container_name: dynamodb-local
     ports:
       - "9000:8000"
@@ -22,8 +22,8 @@ services:
       ALLOWED_SHORTENED_DOMAINS: 'canada.ca,gc.ca'
       AUTH_TOKEN_APP: 'auth_token_app'
       AUTH_TOKEN_NOTIFY: 'auth_token_notify'
-      AWS_ACCESS_KEY_ID: 'AWS_ACCESS_KEY_ID'
-      AWS_SECRET_ACCESS_KEY: 'AWS_SECRET_ACCESS_KEY'
+      AWS_ACCESS_KEY_ID: 'AWSACCESSKEYID'
+      AWS_SECRET_ACCESS_KEY: 'AWSSECRETACCESSKEY'
       AWS_REGION: 'ca-central-1'
       CLOUDFRONT_HEADER: 'localhost'
       DOCS_URL: '/docs'

--- a/.github/workflows/ci_code.yml
+++ b/.github/workflows/ci_code.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       dynamodb-local:
-        image: "amazon/dynamodb-local"
+        image: "amazon/dynamodb-local@sha256:c8702bde709520b90930c20ee430d4123cd731da8e544cc4ccae0e2a78ee4fce"
         ports:
           - 9000:8000
 
@@ -47,7 +47,7 @@ jobs:
         working-directory: ./api
         run: make test
         env:
-          AWS_ACCESS_KEY_ID: "AWS_ACCESS_KEY_ID"
-          AWS_SECRET_ACCESS_KEY: "AWS_SECRET_ACCESS_KEY"
+          AWS_ACCESS_KEY_ID: "AWSACCESSKEYID"
+          AWS_SECRET_ACCESS_KEY: "AWSSECRETACCESSKEY"
           AWS_REGION: "ca-central-1"
           DYNAMODB_HOST: "http://localhost:9000"

--- a/.github/workflows/cypress_e2e.yml
+++ b/.github/workflows/cypress_e2e.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       dynamodb-local:
-        image: "amazon/dynamodb-local"
+        image: "amazon/dynamodb-local@sha256:c8702bde709520b90930c20ee430d4123cd731da8e544cc4ccae0e2a78ee4fce"
         ports:
           - 9000:8000
 
@@ -35,8 +35,8 @@ jobs:
             --endpoint-url http://localhost:9000 \
             --no-cli-pager \
         env:
-          AWS_ACCESS_KEY_ID: 'AWS_ACCESS_KEY_ID'
-          AWS_SECRET_ACCESS_KEY: 'AWS_SECRET_ACCESS_KEY'
+          AWS_ACCESS_KEY_ID: 'AWSACCESSKEYID'
+          AWS_SECRET_ACCESS_KEY: 'AWSSECRETACCESSKEY'
           AWS_REGION: 'ca-central-1'
 
       - name: Install dev dependencies
@@ -57,8 +57,8 @@ jobs:
           ALLOWED_SHORTENED_DOMAINS: "canada.ca,gc.ca"
           AUTH_TOKEN_APP: "auth_token_app"
           AUTH_TOKEN_NOTIFY: "auth_token_notify"
-          AWS_ACCESS_KEY_ID: "AWS_ACCESS_KEY_ID"
-          AWS_SECRET_ACCESS_KEY: "AWS_SECRET_ACCESS_KEY"
+          AWS_ACCESS_KEY_ID: "AWSACCESSKEYID"
+          AWS_SECRET_ACCESS_KEY: "AWSSECRETACCESSKEY"
           AWS_REGION: "ca-central-1"
           CLOUDFRONT_HEADER: "localhost"
           DYNAMODB_HOST: "http://localhost:9000"

--- a/.github/workflows/loadtesting.yml
+++ b/.github/workflows/loadtesting.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       dynamodb-local:
-        image: "amazon/dynamodb-local"
+        image: "amazon/dynamodb-local@sha256:c8702bde709520b90930c20ee430d4123cd731da8e544cc4ccae0e2a78ee4fce"
         ports:
           - 9000:8000
 
@@ -35,8 +35,8 @@ jobs:
             --endpoint-url http://localhost:9000 \
             --no-cli-pager \
         env:
-          AWS_ACCESS_KEY_ID: 'AWS_ACCESS_KEY_ID'
-          AWS_SECRET_ACCESS_KEY: 'AWS_SECRET_ACCESS_KEY'
+          AWS_ACCESS_KEY_ID: 'AWSACCESSKEYID'
+          AWS_SECRET_ACCESS_KEY: 'AWSSECRETACCESSKEY'
           AWS_REGION: 'ca-central-1'
 
 
@@ -65,8 +65,8 @@ jobs:
           ALLOWED_SHORTENED_DOMAINS: "canada.ca,gc.ca"
           AUTH_TOKEN_APP: "auth_token_app"
           AUTH_TOKEN_NOTIFY: "auth_token_notify"
-          AWS_ACCESS_KEY_ID: "AWS_ACCESS_KEY_ID"
-          AWS_SECRET_ACCESS_KEY: "AWS_SECRET_ACCESS_KEY"
+          AWS_ACCESS_KEY_ID: "AWSACCESSKEYID"
+          AWS_SECRET_ACCESS_KEY: "AWSSECRETACCESSKEY"
           AWS_REGION: "ca-central-1"
           CLOUDFRONT_HEADER: "localhost"
           DYNAMODB_HOST: "http://localhost:9000"


### PR DESCRIPTION
# Summary
Update the DynamoDB local AWS access key to conform to the new [v2.0 requirements](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.UsageNotes.html):

> DynamoDB local version 2.0.0 and greater AWS_ACCESS_KEY_ID
> can contain the only letters (A–Z, a–z) and numbers (0–9).